### PR TITLE
New CC: Send CC codes in text files

### DIFF
--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -8,13 +8,49 @@
 */}}
 
 
-{{range .CmdArgs}}
-	{{- $answerLines:= split (exec "cc" .) "\n"}}
+{{define "sendLongMessage"}}	{{/*INPUT: cslice channelIDToSend textToSend stringSeparator*/}}
+	{{$channelID:= index . 0}} {{$text:= index . 1}} {{$separator:= index . 2}}
+	{{$outStr:= ""}}
+
+	{{- range (split $text $separator)}}
+		{{- if gt (add (len $outStr) (len .)) 2000}}
+			{{- sendMessage $channelID $outStr}}
+			{{- $outStr = .}}
+		{{- else}}
+			{{- $outStr = (joinStr $separator $outStr .)}}
+		{{- end}}
+	{{- end}}
+	{{sendMessage $channelID $outStr}}
+{{end}}
+
+{{$args:= cslice}} {{$selectedArgs:= cslice}}
+{{with .ExecData}}
+	{{$args = .}}
+{{else}}
+	{{range .CmdArgs}}
+		{{- if not (in $args .)}}
+			{{- $args = $args.Append .}}
+		{{- end}}
+	{{- end}}
+{{end}}
+{{$numArgs:= len $args}}
+
+{{if gt $numArgs 5}}
+	{{$selectedArgs = slice $args 0 5}}
+{{else}}
+	{{$selectedArgs = $args}}
+{{end}}
+
+{{range $selectedArgs}}
+	{{- $answer:= exec "cc" .}}
+	{{- $answerLines:= split $answer "\n"}}
 	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
 	{{- $firstLine:= index $answerLines 0}}
 
 	{{- if in $firstLine "here is a list of"}}
 		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
+	{{- else if in $firstLine "More than 1 matched command"}}
+		{{- template "sendLongMessage" (cslice nil (printf "`%s`: %s" . $answer) "\n")}}
 	{{- else}}
 		{{- sendMessage nil (complexMessage
 			"content" $firstLine
@@ -22,11 +58,21 @@
 		)}}
 	{{- end}}
 {{else}}
-	{{with (exec "cc")}}
-		{{if gt (len .) 2000}}
-			Use `-cc` command to generate CC list. You shouldn't need to do this, I have to fix that
-		{{else}}
-			{{.}}
-		{{end}}
-	{{end}}
+	{{template "sendLongMessage" (cslice nil (exec "cc") "\n")}}
+{{end}}
+
+{{if gt $numArgs 5}}
+	{{$nextArgs:= slice $args 5 $numArgs}}
+
+	{{if lt (toInt .StackDepth) 2}}
+		{{execCC .CCID nil 0 $nextArgs}}
+	{{else}}
+		{{$error:= "⚠️ WARNING: More than 15 CCs were processed. Run this command to process remaining ones: `-cc2file "}}
+		{{- range $nextArgs}}
+			{{$error = printf "%s \"%s\"" $error .}}
+		{{- end}}
+		{{$error = print $error "`"}}
+
+		{{template "sendLongMessage" (cslice nil $error " ")}}
+	 {{end}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -8,18 +8,21 @@
 */}}
 
 
-{{/*Executing -cc command with input arguments*/}}
-{{$args := parseArgs 1 ""
-	(carg "int" "CC ID")
-}}
-{{$CCanswer:= (exec "cc" ($args.Get 0))}}
+{{range .CmdArgs}}
+	{{- $exec_cc_Answer:= exec "cc" .}}
+	{{- $answerLines:= split $exec_cc_Answer "\n"}}
 
-{{/*If said command throws an error, I'll send its original output. If not, I'll send what I want: Its output in a file*/}}
-{{if reFind "here is a list of" $CCanswer}}
-	{{sendMessage nil $CCanswer}}
+	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
+	{{- $firstLine:= index $answerLines 0}}
+
+	{{- if reFind "here is a list of" $firstLine}}
+		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
+	{{- else}}
+		{{- sendMessage nil (complexMessage
+			"content" $firstLine
+			"file" (joinStr "\n" $extractedCode)
+		)}}
+	{{- end}}
 {{else}}
-	{{sendMessage nil (complexMessage
-		"content" (printf "**CC #%d** successfully exported to file:" ($args.Get 0))
-		"file" $CCanswer
-	)}}
+	{{exec "cc"}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -63,17 +63,5 @@
 {{end}}
 
 {{if gt $numArgs 5}}
-	{{$nextArgs:= slice $args 5 $numArgs}}
-
-	{{if lt (toInt .StackDepth) 2}}
-		{{execCC .CCID nil 0 $nextArgs}}
-	{{else}}
-		{{$error:= "⚠️ WARNING: More than 15 CCs were processed. Run this command to process remaining ones: `-cc2file "}}
-		{{- range $nextArgs}}
-			{{$error = printf "%s \"%s\"" $error .}}
-		{{- end}}
-		{{$error = print $error "`"}}
-
-		{{template "sendLongMessage" (cslice nil $error " ")}}
-	 {{end}}
+	{{scheduleUniqueCC .CCID nil 1 "cc2file - remaining args" (slice $args 5 $numArgs)}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -24,5 +24,11 @@
 		)}}
 	{{- end}}
 {{else}}
-	{{exec "cc"}}
+	{{with (exec "cc")}}
+		{{if gt (len .) 2000}}
+			Use `-cc` command to generate CC list. You shouldn't need to do this, I have to fix that
+		{{else}}
+			{{.}}
+		{{end}}
+	{{end}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -1,0 +1,15 @@
+{{/*Executing -cc command with input arguments*/}}
+{{$args := parseArgs 1 ""
+	(carg "int" "CC ID")
+}}
+{{$CCanswer:= (exec "cc" ($args.Get 0))}}
+
+{{/*If said command throws an error, I'll send its original output. If not, I'll send what I want: Its output in a file*/}}
+{{if reFind "here is a list of" $CCanswer}}
+	{{sendMessage nil $CCanswer}}
+{{else}}
+	{{sendMessage nil (complexMessage
+		"content" (printf "**CC #%d** successfully exported to file:" ($args.Get 0))
+		"file" $CCanswer
+	)}}
+{{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -12,7 +12,7 @@
 	{{$channelID:= index . 0}} {{$text:= index . 1}} {{$separator:= index . 2}}
 	{{$outStr:= ""}}
 
-	{{- range (split $text $separator)}}
+	{{ range (split $text $separator)}}
 		{{- if gt (add (len $outStr) (len .)) 2000}}
 			{{- sendMessage $channelID $outStr}}
 			{{- $outStr = .}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -2,7 +2,7 @@
 	This command sends your CC(s) code in a text file, rather than "plain" Discord messages, preserving Tabs, markdown, etc. 
 	You can especify more than one ID or trigger, and bot will generate one file per input parameter. If none are provided, output will be CC list
 	
-	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "test" 23`
+	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "te st" 23`
 	Recommended trigger: Command trigger with trigger `cc2file`.
 	Configuration variables: None
 */}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -4,6 +4,7 @@
 	
 	Usage: `-cc2file <ID_of_CC>`. For example: `-cc2file 10`
 	Recommended trigger: Command trigger with trigger `cc2file`.
+	Configuration variables: None
 */}}
 
 

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -19,7 +19,7 @@
 		{{- else}}
 			{{- $outStr = (joinStr $separator $outStr .)}}
 		{{- end}}
-	{{- end}}
+	{{ end}}
 	{{sendMessage $channelID $outStr}}
 {{end}}
 

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -9,13 +9,11 @@
 
 
 {{range .CmdArgs}}
-	{{- $exec_cc_Answer:= exec "cc" .}}
-	{{- $answerLines:= split $exec_cc_Answer "\n"}}
-
+	{{- $answerLines:= split (exec "cc" .) "\n"}}
 	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
 	{{- $firstLine:= index $answerLines 0}}
 
-	{{- if in $firstLine "here is a list of" }}
+	{{- if in $firstLine "here is a list of"}}
 		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
 	{{- else}}
 		{{- sendMessage nil (complexMessage

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -18,7 +18,7 @@
 			{{- $outStr = .}}
 		{{- else}}
 			{{- $outStr = (joinStr $separator $outStr .)}}
-		{{- end}}
+		{{- end -}}
 	{{ end}}
 	{{sendMessage $channelID $outStr}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -15,7 +15,7 @@
 	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
 	{{- $firstLine:= index $answerLines 0}}
 
-	{{- if reFind "here is a list of" $firstLine}}
+	{{- if in $firstLine "here is a list of" }}
 		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
 	{{- else}}
 		{{- sendMessage nil (complexMessage

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -1,3 +1,12 @@
+{{/*
+	This command sends your CC code in a text file, rather than "plain" Discord messages, preserving Tabs, markdown, etc. 
+	If input ID is invalid (i.e. CC doesn't exist), bot will send a message listing all CCs (usual `-cc` output)
+	
+	Usage: `-cc2file <ID_of_CC>`. For example: `-cc2file 10`
+	Recommended trigger: Command trigger with trigger `cc2file`.
+*/}}
+
+
 {{/*Executing -cc command with input arguments*/}}
 {{$args := parseArgs 1 ""
 	(carg "int" "CC ID")

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -1,8 +1,8 @@
 {{/*
-	This command sends your CC code in a text file, rather than "plain" Discord messages, preserving Tabs, markdown, etc. 
-	If input ID is invalid (i.e. CC doesn't exist), bot will send a message listing all CCs (usual `-cc` output)
+	This command sends your CC(s) code in a text file, rather than "plain" Discord messages, preserving Tabs, markdown, etc. 
+	You can especify more than one ID or trigger, and bot will generate one file per input parameter. If none are provided, output will be CC list
 	
-	Usage: `-cc2file <ID_of_CC>`. For example: `-cc2file 10`
+	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "test" 23`
 	Recommended trigger: Command trigger with trigger `cc2file`.
 	Configuration variables: None
 */}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -50,7 +50,8 @@
 	{{- if in $firstLine "here is a list of"}}
 		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
 	{{- else if in $firstLine "More than 1 matched command"}}
-		{{- template "sendLongMessage" (cslice nil (printf "`%s`: %s" . $answer) "\n")}}
+		{{- $msj:= reReplace "``" (printf "`%s`: %s" . $answer) "`<Empty trigger specified>`"}}
+		{{- template "sendLongMessage" (cslice nil $msj "\n")}}
 	{{- else}}
 		{{- sendMessage nil (complexMessage
 			"content" $firstLine


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I add a new CC, which sends your CCs in text files, rather than Discord messages. This preserves tabs, markdown and doesn't flood the chat

**Status**
Functional, but can be improved:
- ~~File content is **full** `-cc` output, not only the extracted code from it~~ Done
- ~~Delete my comments? To reduce code size (chars)~~ Done, but I can put them back
- ~~You can't search using trigger. Only CC ID~~ Fixed
- ~~Export more than one CC in one execution. For example, `-cc2file 11 22 33` would return 3 files, one with each CC~~ Done!

Now it has a bug: Output to `-cc2file` (with no arguments, it generates CC list) if your server has a lot of CCs, was
> Custom command response was longer than 2k (contact an admin on the server...)

My workaround is asking user to execute `-cc` just for generating CC list. But that's not ideal...


- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)