### PR TITLE
Add CC set for custom groups of Cards Against Humanity packs

### DIFF
--- a/fun/CAHPackGroups/README.md
+++ b/fun/CAHPackGroups/README.md
@@ -2,20 +2,23 @@
 Make groups of card packs for YAGPDB Cards Against Humanity games!
 
 ## Setup
-This repo contains a set of custom commands for use with [Yet Another General Purpose Discord Bot (YAGPDB)](https://yagpdb.xyz).
+This folder contains a set of custom commands for use with [Yet Another General Purpose Discord Bot (YAGPDB)](https://yagpdb.xyz).
 
 Each command has a corresponding text file. To set up the command system, follow these steps:
 - Find the Custom Commands section of the YAGPDB Control Panel (under `Core > Custom Commands` in the left sidebar).
 - (Optional but recommended) Create a new custom command group (by clicking the plus icon next to the `Ungrouped` tab). Set the desired permissions for this group of commands.
 - Hit `Save group settings`.
-- Hit `Create a new Custom Command` (the other big green button at the bottom of the page).
-  + Pick a text file from this repository to start with.
+- To add a new command:
+  + Hit `Create a new Custom Command` (the other big green button at the bottom of the page).
+  + Pick a file from this repository to start with.
   + Choose `Command (mention/cmd prefix)` as the `Trigger type`.
-  + Set the command's trigger to the name of the file you just chose (without the `.txt` ending).
+  + Set the command's trigger to the name of the file you just chose (without the `.go.tmpl` ending).
   + Paste the contents of the file into the command's `Response` box.
-- Repeat the above step for all other text files in this repo.
-- Test it out! The commands will provide usage tips if you do something wrong.
+  + Some commands have configuration variables that you'll need to change. These will be near the top of the command, right after the description block.
+- Repeat the above step for all other files in this repo (except this one, of course).
+- Test it out! Some of the commands will provide usage tips if you do something wrong.
 
 ## Troubleshooting
 Since this is premade code, it should "just work."
 However, if things go wrong or don't work at all, try rechecking the permissions (for the group as well as the individual command), or re-paste the code into the `Response` box.
+If all else fails, contact us in the YAGPDB support server!

--- a/fun/CAHPackGroups/README.md
+++ b/fun/CAHPackGroups/README.md
@@ -1,0 +1,21 @@
+# YAGPDB-CAH-groups
+Make groups of card packs for YAGPDB Cards Against Humanity games!
+
+## Setup
+This repo contains a set of custom commands for use with [Yet Another General Purpose Discord Bot (YAGPDB)](https://yagpdb.xyz).
+
+Each command has a corresponding text file. To set up the command system, follow these steps:
+- Find the Custom Commands section of the YAGPDB Control Panel (under `Core > Custom Commands` in the left sidebar).
+- (Optional but recommended) Create a new custom command group (by clicking the plus icon next to the `Ungrouped` tab). Set the desired permissions for this group of commands.
+- Hit `Save group settings`.
+- Hit `Create a new Custom Command` (the other big green button at the bottom of the page).
+  + Pick a text file from this repository to start with.
+  + Choose `Command (mention/cmd prefix)` as the `Trigger type`.
+  + Set the command's trigger to the name of the file you just chose (without the `.txt` ending).
+  + Paste the contents of the file into the command's `Response` box.
+- Repeat the above step for all other text files in this repo.
+- Test it out! The commands will provide usage tips if you do something wrong.
+
+## Troubleshooting
+Since this is premade code, it should "just work."
+However, if things go wrong or don't work at all, try rechecking the permissions (for the group as well as the individual command), or re-paste the code into the `Response` box.

--- a/fun/CAHPackGroups/delgroup.go.tmpl
+++ b/fun/CAHPackGroups/delgroup.go.tmpl
@@ -1,0 +1,23 @@
+{{/*
+	This command deletes a group of CAH card packs.
+
+	Usage: `-delgroup "group name"`
+
+	Recommended trigger: `delgroup`
+	Trigger type: Command
+
+	Credits:
+	LRitzdorf <https://github.com/LRitzdorf>
+*/}}
+
+{{ $fullKey := joinStr "" "group " (index .CmdArgs 0) }}
+{{ if ne (len .CmdArgs) 1 }}
+    Command usage: `-delgroup "group name"`
+Use group names previously set up with the `-setgroup` command, viewable with `-listgroups`.
+You can have a group name with spaces, but make sure to put it in quotes!
+{{ else if (dbGet 0 $fullKey) }}
+    {{ dbDel 0 $fullKey }}
+    Pack group `{{index .CmdArgs 0}}` deleted.
+{{ else }}
+    Pack group `{{index .CmdArgs 0}}` does not exist.
+{{ end }}

--- a/fun/CAHPackGroups/endgame.go.tmpl
+++ b/fun/CAHPackGroups/endgame.go.tmpl
@@ -1,0 +1,13 @@
+{{/*
+	This command ends the current CAH game. It's really just an alias of `cah end`, added for syntactic consistency with `newgame` in this command set.
+
+	Usage: `-endgame`
+
+	Recommended trigger: `endgame`
+	Trigger type: Command
+
+	Credits:
+	LRitzdorf <https://github.com/LRitzdorf>
+*/}}
+
+{{ exec "cah end" }}

--- a/fun/CAHPackGroups/listgroups.go.tmpl
+++ b/fun/CAHPackGroups/listgroups.go.tmpl
@@ -1,0 +1,27 @@
+{{/*
+	This command lists all currently configured CAH card pack groups.
+
+	Usage: `-listgroups`
+
+	Recommended trigger: `listgroups`
+	Trigger type: Command
+
+	Credits:
+	LRitzdorf <https://github.com/LRitzdorf>
+*/}}
+
+{{ $pattern := "" }}
+{{ if ne (len .CmdArgs) 0 }}
+    Filtering groups by `{{index .CmdArgs 0}}` and ignoring other arguments.
+    {{- $pattern = joinStr "" "group %" (index .CmdArgs 0) "%" }}
+{{- else }}
+    {{- $pattern = "group %" }}
+{{- end }}
+{{- $groups := dbGetPattern 0 $pattern 100 0 }}
+`Group name` - pack-1 pack-2 ...
+{{ range $groups }}
+    {{- $strippedKey := slice .Key 6 (len .Key) }}
+`{{$strippedKey}}` - {{.Value}}
+{{- else }}
+    No pack groups defined. Use `-setgroup "group name" "pack-1 pack-2 ..."` to set some up!
+{{ end }}

--- a/fun/CAHPackGroups/newgame.go.tmpl
+++ b/fun/CAHPackGroups/newgame.go.tmpl
@@ -1,0 +1,50 @@
+{{/*
+	This command starts a new CAH game using the specified packs and pack groups.
+	It first checks whether each argument is a valid pack group and, if so, expands it into its component packs. If not, that argment is assumed to be an individual pack and is skipped. After expanding all applicable pack groups, the resulting list of packs is used to start a new game, and all members with the CAH role are pinged.
+
+	Usage: `-newgame pack1 "pack 2" packGroup1 "pack group 2" etc` (no specific ordering necessary)
+
+	Recommended trigger: `newgame`
+	Trigger type: Command
+
+	Credits:
+	LRitzdorf <https://github.com/LRitzdorf>
+*/}}
+
+{{/* This is the default list of packs to use if nothing is specified: */}}
+{{ $packs := "*" }}
+{{/* This is the ID of the CAH role, which will be pinged when a new game is started: */}}
+{{ $CAHrole := 123456789 }}
+
+{{ if gt (len .CmdArgs) 0 }}
+    {{ $star := false }}
+    {{ $reqst := cslice }}
+    {{ range .CmdArgs }}
+        {{- $dbResult := dbGet 0 (joinStr "" "group " .) }}
+        {{- if $dbResult }}
+            {{- $reqst = $reqst.Append $dbResult.Value }}
+        {{- else }}
+            {{- $reqst = $reqst.Append . }}
+        {{- end }}
+    {{- end }}
+    {{ $packs = "" }}
+    {{ range $reqst }}
+        {{- if (eq . "*") }}
+            {{- $star = true }}
+        {{- else }}
+            {{- if eq (len (reFindAll (joinStr "" "(" . ")") $packs)) 0 }}
+                {{- $packs = joinStr " " $packs . }}
+           {{- end }}
+        {{- end }}
+    {{- end }}
+    {{ if $star }}
+        {{ $packs = "*" }}
+    {{ end }}
+{{ end }}
+ 
+{{ $resp := exec "cah create" $packs }}
+{{ if eq (len (reFind "Unknown pack" $resp)) 0 }}
+    {{.User.Mention}} has summoned all the{{mentionRoleID $CAHrole}}s to a new game!
+We'll be using the following pack(s): `{{$packs}}`.
+{{ end }}
+{{ $resp }}

--- a/fun/CAHPackGroups/setgroup.go.tmpl
+++ b/fun/CAHPackGroups/setgroup.go.tmpl
@@ -1,0 +1,21 @@
+{{/*
+	This command creates a new group of CAH card packs, or edits an existing one.
+	Note that the packs to form the specified group must all be in the same set of quotes.
+
+	Usage: `-setgroup "group name" "pack1 pack2 etc"`
+
+	Recommended trigger: `setgroup`
+	Trigger type: Command
+
+	Credits:
+	LRitzdorf <https://github.com/LRitzdorf>
+*/}}
+
+{{ if ne (len .CmdArgs) 2 }}
+    Command usage: `-setgroup "group name" "pack1 pack2 etc"`
+Use pack names from the `-cah packs` command. All packs must be in one set of quotes, separated by spaces.
+You can have a group name with spaces, but make sure to put it in quotes!
+{{ else }}
+    {{ dbSet 0 (joinStr "" "group " (index .CmdArgs 0)) (index .CmdArgs 1) }}
+    Pack group `{{index .CmdArgs 0}}` set to `{{index .CmdArgs 1}}`.
+{{ end }}


### PR DESCRIPTION
# Changes

This PR adds a new set of custom commands, aimed at Cards Against Humanity (CAH) players. Specifically, these commands allow server members to create custom *groups of packs* from the built-in `cah` system.

While the README and descriptive blocks in each file provide additional details, the general outlines are as follows:
- Groups of packs are created and stored in YAGPDB's database system, and can be edited at any time. No validation is performed upon editing (so a user could add a nonexistent pack to a group).
- When the `newgame` command is used, all arguments that match existing pack groups are expanded into their constituent packs. Other arguments are assumed to be individual packs and are left alone. The resulting set of packs is then used to start a new CAH game, and members with a user-configured role are pinged to join the game.
- Commands to view and delete groups are also provided.

# Status

- [x] Code changes have been tested on an instance of YAGPDB (added as CCs for my server, using the main YAGPDB instance)
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
