### PR TITLE
Allow year to be optional in the birthday command

### DIFF
--- a/birthday/README.md
+++ b/birthday/README.md
@@ -6,6 +6,7 @@ All commands can be used with bday or birthday. Example: -getbday or -getbirthda
 This code will also kick/ban users if they are under 13 years old, if you want it to.<p>
 Change ONLY the user variables<p>
 $mods is the list of the Roles IDs that should be able to use all commands.<p>
+Year can be set to optional by editing the $yearOptional variable to true, the default year is 2000 when this variable is true.<p>
 User can only set their birthday once. After that a mod will have to set a new one or delete the existing one.<p>
 Trigger Type: regex<p>
 Trigger: \A-(my|start|stop|set|get|del)b(irth)?days?

--- a/birthday/birthday.go.tmpl
+++ b/birthday/birthday.go.tmpl
@@ -3,6 +3,7 @@
 {{$channelID := 730216142924415006}} {{/* Channel ID to send the bday msgs */}}
 {{$bdayMsg := "Congratulations for your birthday!"}}
 {{$invertedOrder := false}}
+{{$yearOptional := false}}
 {{$kickUnderAge := false}}
 {{$banUnderAge := true}}
 {{/* End */}}
@@ -23,8 +24,8 @@
 			{{if and (eq (len .) 2) $isMod}} {{with index . 1 | userArg}} {{$user = .}} {{else}} {{$error = "Invalid User."}} {{end}} {{end}}
 		{{end}}
 		{{with $map}}
-			{{if eq (len .) 3}} {{$counter := 0}}
-				{{$year := index . 2 | toInt}}
+			{{if or (eq (len .) 3) $yearOptional}} {{$counter := 0}}
+				{{if eq (len .) 3}}{{$year = index . 2 | toInt}}{{else}}{{$year = 2000}}{{end}}
 				{{if $invertedOrder}} {{$day = index . 1 | toInt}} {{$month = index . 0 | toInt}}
 				{{else}} {{$day = index . 0 | toInt}} {{$month = index . 1 | toInt}}
 				{{end}}


### PR DESCRIPTION
Added $yearOptional as a true/false variable and slightly changed how $year is parsed. Default year is 2000 to allow February 29 as a valid date.

Works as far as I tested.
Inverted mode works, setbday works, and mybday works.

- [ x] Code changes have been tested on an instance of YAGPDB, or there are no code changes

- [ x] I have read and followed the [contribution guide](../CONTRIBUTING.md)

Resolves #139 