### PR TITLE
fix(suggestion): correct regex construction

### DIFF
--- a/suggestion/suggestion.go.tmpl
+++ b/suggestion/suggestion.go.tmpl
@@ -59,7 +59,7 @@
 	{{$authorID:=0}}{{$message:=.nil}}{{$channel:=.nil}}{{$rest:=""}}{{$command:=""}}{{$type:=""}}{{$SNum:=0}}
 	{{$Syntax =print .Cmd " <Suggestion_ID> <Message/Arguments>"}}
 
-	{{with reFindAllSubmatches (print `(?si)\A(?:\` $Escaped_Prefix `\s?|\S+\s*)(?:(del|edit)\w+|\w+\s+(\w+))\s+(\d+)\s*(.*)`) .Message.Content}}
+	{{with reFindAllSubmatches (print `(?si)\A(?:` $Escaped_Prefix `\s?|\S+\s*)(?:(del|edit)\w+|\w+\s+(\w+))\s+(\d+)\s*(.*)`) .Message.Content}}
 		{{$command =lower (or (index . 0 1) (index . 0 2))}}
 		{{$mID:=index . 0 3}}
 		{{$rest =index . 0 4}}


### PR DESCRIPTION
Very rookie mistake, oversaw a `reFindAllSubmatches` causing it to error out with certain prefixes.


**Status**
- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)