### PR TITLE
cc2file - Medium update

### DIFF
--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -85,7 +85,7 @@
 
 {{/*Convert each $blacklisted_CCIDs to a RegEx pattern*/}}
 {{range $index, $CCID:= $blacklisted_CCIDs}}
-	{{- $blacklisted_CCIDs.Set $index (printf "^#%d.*" $CCID)}}
+	{{- $blacklisted_CCIDs.Set $index (printf "^#%d -.*" $CCID)}}
 {{end}}
 
 {{/*Process each selected argument in this execution*/}}
@@ -144,3 +144,9 @@
 {{if and (not $limitTo5CCs) (gt $numArgs 5)}}
 	{{scheduleUniqueCC .CCID nil 1 "cc2file - remaining args" (slice $args 5 $numArgs)}}
 {{end}}
+
+{{/*REGEX para matchear parametro "Custom usage text when invalid args provided" de parseArgs: `parseArgs \d+ "(.+)"`*/}}
+
+{{/*REGEX firstLine: `^#\s*(\d+) - (.*)(?:(?:: \x60(.*)\x60 - Case sensitive trigger: \x60(.+)\x60)|\b) - Group: \x60(.+)\x60$`
+	Robado de Crafter (MIT): https://github.com/TheHDCrafter/yagpdb-cc/blob/master/CustomCommands%20Replacement/command.gotmpl#L85
+*/}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -144,9 +144,3 @@
 {{if and (not $limitTo5CCs) (gt $numArgs 5)}}
 	{{scheduleUniqueCC .CCID nil 1 "cc2file - remaining args" (slice $args 5 $numArgs)}}
 {{end}}
-
-{{/*REGEX para matchear parametro "Custom usage text when invalid args provided" de parseArgs: `parseArgs \d+ "(.+)"`*/}}
-
-{{/*REGEX firstLine: `^#\s*(\d+) - (.*)(?:(?:: \x60(.*)\x60 - Case sensitive trigger: \x60(.+)\x60)|\b) - Group: \x60(.+)\x60$`
-	Robado de Crafter (MIT): https://github.com/TheHDCrafter/yagpdb-cc/blob/master/CustomCommands%20Replacement/command.gotmpl#L85
-*/}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -1,17 +1,26 @@
 {{/*
 	This command sends your CC(s) code in a text file, rather than "plain" Discord messages, preserving Tabs, markdown, etc. 
 	You can especify more than one ID or trigger, and bot will generate one file per input parameter. If none are provided, output will be CC list
-	
-	Recommended trigger: "cc2file"
+
 	Trigger type: Command
+	Recommended trigger 1: "cc2file"
+	Recommended trigger 2: "cc" IF you disable built-in "cc" command, via CommandOverrides
 	
 	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "te st" 23`
 */}}
 
 {{/* CONFIGURATION AREA STARTS */}}
-	{{$limitTo5CCs:= true}}				{{/*If `true`, bot will do that. Prevents flood in the chat*/}}
-	{{$CCInfo_MessageContent:= true}}		{{/*If `true`, the info of each CC will be included in the message content*/}}
-	{{$CCInfo_Attachment:= false}}			{{/*If `true`, the info of each CC will be included in the attached file*/}}
+	{{/*If `true`, bot will do that. Prevents flood in the chat*/}}
+	{{$limitTo5CCs:= true}}
+
+	{{/*If `true`, the info of each CC will be included in the message content*/}}
+	{{$CCInfo_MessageContent:= true}}
+
+	{{/*If `true`, the info of each CC will be included in the attached file*/}}
+	{{$CCInfo_Attachment:= true}}
+
+	{{/*These CCs will NOT be processed. DON'T QUOTE THE NUMBERS NOR ADD "#" TO THEM*/}}
+	{{$blacklisted_CCIDs:= cslice 1234 5678}}
 {{/* CONFIGURATION AREA ENDS */}}
 
 
@@ -43,7 +52,7 @@
 		{{- end -}}
 	{{end}}
 
-	{{/*Send the last message when range loop is over*/}}
+	{{/*Send the last message, that was left when range loop ended*/}}
 	{{sendMessage .channelID $outStr}}
 {{end}}
 
@@ -74,6 +83,11 @@
 	{{$selectedArgs = $args}}
 {{end}}
 
+{{/*Convert each $blacklisted_CCIDs to a RegEx pattern*/}}
+{{range $index, $CCID:= $blacklisted_CCIDs}}
+	{{- $blacklisted_CCIDs.Set $index (printf "^#%d.*" $CCID)}}
+{{end}}
+
 {{/*Process each selected argument in this execution*/}}
 {{range $selectedArgs}}
 	{{/*EXECute "-cc" and extract stuff from its output*/}}
@@ -81,6 +95,14 @@
 	{{- $answerLines:= split $answer "\n"}}
 	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
 	{{- $firstLine:= index $answerLines 0}}
+	{{- $blacklisted:= false}}
+
+	{{/*Check if that CC was $blacklisted*/}}
+	{{range $blacklisted_CCIDs}}
+		{{- if reFind . $firstLine}}
+			{{$blacklisted = true}}
+		{{- end}}
+	{{end}}
 
 	{{/*Check if Answer's $firstLine is actually an error message*/}}
 	{{- if in $firstLine "here is a list of"}}
@@ -89,6 +111,8 @@
 		{{/*Insert argument in message output, and if it's empty, replace it with "<Empty trigger specified>"*/}}
 		{{- $msj:= reReplace "``" (printf "`%s`: %s" . $answer) "`<Empty trigger specified>`"}}
 		{{- template "sendLongMessage" (sdict "channelID" nil "text" $msj "separator" "\n")}}
+	{{- else if $blacklisted}}
+		{{- sendMessage nil (printf "🚫 CC `%s` is blacklisted" .)}}
 	{{- else}}
 		{{/*No error message, so send CC's code and info*/}}
 		{{- $content:= ""}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -17,7 +17,7 @@
 	{{$CCInfo_MessageContent:= true}}
 
 	{{/*If `true`, the info of each CC will be included in the attached file*/}}
-	{{$CCInfo_Attachment:= true}}
+	{{$CCInfo_Attachment:= false}}
 
 	{{/*These CCs will NOT be processed. DON'T QUOTE THE NUMBERS NOR ADD "#" TO THEM*/}}
 	{{$blacklisted_CCIDs:= cslice 1234 5678}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -5,8 +5,13 @@
 	Trigger type: Command
 	Recommended trigger 1: "cc2file"
 	Recommended trigger 2: "cc" IF you disable built-in "cc" command, via CommandOverrides
-	
+
 	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "te st" 23`
+
+	Credits:
+		- MatiasMFM2001: Main author
+		- Joe L.: Reviewer
+		- TheHDCrafter: Some Regex I've used
 */}}
 
 {{/* CONFIGURATION AREA STARTS */}}
@@ -21,6 +26,9 @@
 
 	{{/*These CCs will NOT be processed. DON'T QUOTE THE NUMBERS NOR ADD "#" TO THEM*/}}
 	{{$blacklisted_CCIDs:= cslice 1234 5678}}
+
+	{{/*If false, blacklisted CCs will be strikethroughted from CC list. If true, they will be left out*/}}
+	{{$hideBlacklistedCCs:= false}}
 {{/* CONFIGURATION AREA ENDS */}}
 
 
@@ -29,9 +37,9 @@
 	sendLongMessage is able to split a long text and send them in individual messages (of 2000 chars long max)
 
 	INPUT (arguments) is an SDICT with keys:
-		"channelID" = Channel ID/Name/nil where message(s) will be sent
-		"text" = The content itself you want to send
-		"separator" = A string that will define when a 'word' starts or ends
+		[String/Int/nil] "channelID" = Channel ID/Name/nil where message(s) will be sent
+		[String] "text" = The content itself you want to send
+		[String] "separator" = This will define when a 'word' starts or ends
 */}}
 {{define "sendLongMessage"}}
 	{{$outStr:= ""}}
@@ -56,7 +64,52 @@
 	{{sendMessage .channelID $outStr}}
 {{end}}
 
+{{/*
+	parseCC executes "-cc .argument" and extracts all possible information from it
 
+	INPUT is an SDICT with keys:
+		[String] "argument" = The CC ID or Trigger to parse
+
+	OUTPUT is the same SDICT with keys:
+		[String] "error" = If there are errors, they will be returned here (as a string)
+		[Int] "CCID" = The ID of processed CC
+		[String] "triggerType" = The type of the trigger this CC has (i.e. "None", "Command", "Regex", etc)
+		[String] "trigger" = The trigger itself this CC has (i.e. "cc2file", ".*", etc)
+		[Bool] "caseSensitive" = If lowercase and uppercase characters, are not considered equal
+		[String] "group" = CC group, this CC belongs to
+		[String] "code" = Executable source code of this CC
+*/}}
+{{define "parseCC"}}
+	{{/*EXECute "-cc" and extract stuff from its output*/}}
+	{{$answer:= exec "cc" .argument}}
+	{{$answerLines:= split $answer "\n"}}
+	{{$extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
+	{{$firstLine:= index $answerLines 0}}
+
+	{{/*Check if Answer's $firstLine is actually an error message*/}}
+	{{- if in $firstLine "here is a list of"}}
+		{{.Set "error" (printf "❌ CC `%s` not found" .argument)}}
+	{{- else if in $firstLine "More than 1 matched command"}}
+		{{/*Insert argument in message output, and if it's empty, replace it with "<Empty trigger specified>"*/}}
+		{{.Set "error" (reReplace "``" (printf "`%s`: %s" .argument $answer) "`<Empty trigger specified>`")}}
+	{{end}}
+
+	{{/*If not, extract info from the CC*/}}
+	{{if not .error}}
+		{{/*Modified copy of TheHDCrafter's Regex expression. Licensed under MIT*/}}
+		{{$parsedFirstLine:= reFindAllSubmatches `^#\s*(\d+) - ((.*)(?:(?:: \x60(.*)\x60 - Case sensitive trigger: \x60(.+)\x60)|\b))? - Group: \x60(.+)\x60$` $firstLine}}
+
+		{{.Set "CCID" (index $parsedFirstLine 0 1 | toInt)}}
+		{{.Set "triggerType" (or (index $parsedFirstLine 0 3) "None")}}
+		{{.Set "trigger" (index $parsedFirstLine 0 4)}}
+		{{.Set "caseSensitive" (index $parsedFirstLine 0 5 | eq "true")}}
+		{{.Set "group" (index $parsedFirstLine 0 6)}}
+
+		{{.Set "code" (joinStr "\n" $extractedCode)}}
+	{{end}}
+{{end}}
+
+{{/*EXECUTION STARTS HERE*/}}
 {{/*If CC was called via execCC/scheduleUniqueCC, use .ExecData as the $args. If not, use .CmdArgs*/}}
 {{$args:= cslice}}
 {{with .ExecData}}
@@ -83,49 +136,38 @@
 	{{$selectedArgs = $args}}
 {{end}}
 
-{{/*Convert each $blacklisted_CCIDs to a RegEx pattern*/}}
-{{range $index, $CCID:= $blacklisted_CCIDs}}
-	{{- $blacklisted_CCIDs.Set $index (printf "^#%d -.*" $CCID)}}
-{{end}}
-
 {{/*Process each selected argument in this execution*/}}
 {{range $selectedArgs}}
-	{{/*EXECute "-cc" and extract stuff from its output*/}}
-	{{- $answer:= exec "cc" .}}
-	{{- $answerLines:= split $answer "\n"}}
-	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
-	{{- $firstLine:= index $answerLines 0}}
-	{{- $blacklisted:= false}}
+	{{- $params:= sdict "argument" .}}
+	{{- template "parseCC" $params}}
 
 	{{/*Check if that CC was $blacklisted*/}}
-	{{range $blacklisted_CCIDs}}
-		{{- if reFind . $firstLine}}
-			{{$blacklisted = true}}
-		{{- end}}
-	{{end}}
-
-	{{/*Check if Answer's $firstLine is actually an error message*/}}
-	{{- if in $firstLine "here is a list of"}}
-		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
-	{{- else if in $firstLine "More than 1 matched command"}}
-		{{/*Insert argument in message output, and if it's empty, replace it with "<Empty trigger specified>"*/}}
-		{{- $msj:= reReplace "``" (printf "`%s`: %s" . $answer) "`<Empty trigger specified>`"}}
-		{{- template "sendLongMessage" (sdict "channelID" nil "text" $msj "separator" "\n")}}
-	{{- else if $blacklisted}}
+	{{- if $params.error}}
+		{{- sendMessage nil $params.error}}
+	{{- else if in $blacklisted_CCIDs $params.CCID}}
 		{{- sendMessage nil (printf "🚫 CC `%s` is blacklisted" .)}}
 	{{- else}}
 		{{/*No error message, so send CC's code and info*/}}
 		{{- $content:= ""}}
-		{{- $attachment:= joinStr "\n" $extractedCode}}
+		{{- $attachment:= $params.code}}
 
 		{{/*If $CCInfo_MessageContent flag is set, the info will be sent as message content*/}}
 		{{- if $CCInfo_MessageContent}}
-			{{- $content = $firstLine}}
+			{{- $content = printf "#%d - %s: `%s` - Case sensitive trigger: `%t` - Group: `%s`" $params.CCID $params.triggerType $params.trigger $params.caseSensitive $params.group}}
 		{{- end}}
 
 		{{/*If $CCInfo_Attachment flag is set, the info will be a comment in message's attachment*/}}
 		{{- if $CCInfo_Attachment}}
-			{{- $attachment = printf "{{/* CC INFO: %s */}}\n\n%s" $firstLine $attachment}}
+			{{/*Generate the $leadingComment*/}}
+			{{- $leadingComment:= printf "{{/*\n\tDescription:\n\n\tUsage:\n"}}
+
+			{{- range reFindAllSubmatches `parseArgs\s+\d+\s+"(.+)"` $params.code}}
+				{{- $leadingComment = printf "%s\t\t\"%s\"\n" $leadingComment (index . 1)}}
+			{{- end}}
+
+			{{- $leadingComment = printf "%s\n\tRecomended trigger: \"%s\"\n\tTrigger type: %s\n\n\tCredits:\n*/}}" $leadingComment $params.trigger $params.triggerType}}
+
+			{{- $attachment = printf "%s\n\n%s" $leadingComment $attachment}}
 		{{- end}}
 
 		{{- sendMessage nil (complexMessage
@@ -137,7 +179,31 @@
 	{{- sleep 1}}
 {{else}}
 	{{/*If there are 0 args, send full CC list*/}}
-	{{template "sendLongMessage" (sdict "channelID" nil "text" (exec "cc") "separator" "\n")}}
+	{{$answerLines:= split (exec "cc") "\n"}}
+
+	{{/*Save the first line, and the rest of them, in different variables*/}}
+	{{$newMessage:= index $answerLines 0}}
+	{{$answerLines:= slice $answerLines 1 (sub (len $answerLines) 1) | cslice.AppendSlice}}
+
+	{{/*For each CC, if It's blacklisted, strikethrough whole line*/}}
+	{{range $index, $content:= $answerLines}}
+		{{- $CCID:= index (reFindAllSubmatches `^\x60#([0-9 ]{3})` $content) 0 1 | toInt}}
+
+		{{- if in $blacklisted_CCIDs $CCID}}
+			{{- if $hideBlacklistedCCs}}
+				{{- $answerLines.Set $index ""}}
+			{{- else}}
+				{{- $answerLines.Set $index (printf "~~%s~~" $content)}}
+			{{- end}}
+		{{- end}}
+	{{end}}
+
+	{{/*A DIY "joinStr `\n` $answerLines"*/}}
+	{{range $answerLines}}
+		{{- $newMessage = printf "%s\n%s" $newMessage .}}
+	{{end}}
+
+	{{template "sendLongMessage" (sdict "channelID" nil "text" $newMessage "separator" "\n")}}
 {{end}}
 
 {{/*If $limitTo5CCs flag is not set, and there are still arguments left, execute CC again to process them*/}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -14,42 +14,46 @@
 	{{$CCInfo_Attachment:= false}}			{{/*If `true`, the info of each CC will be included in the attached file*/}}
 {{/* CONFIGURATION AREA ENDS */}}
 
-{{define "sendLongMessage"}}	{{/*INPUT: cslice channelIDToSend textToSend stringSeparator*/}}
-	{{$channelID:= index . 0}} {{$text:= index . 1}} {{$separator:= index . 2}}
+
+
+{{/*
+	sendLongMessage is able to split a long text and send them in individual messages (of 2000 chars long max)
+
+	INPUT (arguments) is an SDICT with keys:
+		"channelID" = Channel ID/Name/nil where message(s) will be sent
+		"text" = The content itself you want to send
+		"separator" = A string that will define when a 'word' starts or ends
+*/}}
+{{define "sendLongMessage"}}
 	{{$outStr:= ""}}
 
-	{{range (split $text $separator)}}
-		{{- if gt (add (len $outStr) (len .)) 2000}}
-			{{- sendMessage $channelID $outStr}}
-			{{- $outStr = .}}
-		{{- else}}
-			{{- $outStr = joinStr $separator $outStr .}}
-		{{- end -}}
+	{{/*If separator is not found on the text, fallback to a default empty string*/}}
+	{{if not (in .text .separator)}}
+		{{.Set "separator" ""}}
 	{{end}}
 
-	{{sendMessage $channelID $outStr}}
-{{end}}
-
-{{define "sendLongMessageV2"}}	{{/*INPUT: sdict "channelID" $ID "text" $Text "separator" $Sepr*/}}
-	{{$outStr:= ""}}
-
+	{{/*Split text in 'words' and iterate over them*/}}
 	{{range (split .text .separator)}}
+		{{/*Keep appending words while length is under the limit. Then, send the message and "reset" the content for a new message*/}}
 		{{- if gt (add (len $outStr) (len .)) 2000}}
-			{{- sendMessage .channelID $outStr}}
+			{{- sendMessage $.channelID $outStr}}
 			{{- $outStr = .}}
 		{{- else}}
-			{{- $outStr = joinStr .separator $outStr .}}
+			{{- $outStr = joinStr $.separator $outStr .}}
 		{{- end -}}
 	{{end}}
 
+	{{/*Send the last message when range loop is over*/}}
 	{{sendMessage .channelID $outStr}}
 {{end}}
 
 
+{{/*If CC was called via execCC/scheduleUniqueCC, use .ExecData as the $args. If not, use .CmdArgs*/}}
 {{$args:= cslice}}
 {{with .ExecData}}
 	{{$args = .}}
 {{else}}
+	{{/*Delete duplicated $args*/}}
 	{{range .CmdArgs}}
 		{{- if not (in $args .)}}
 			{{- $args = $args.Append .}}
@@ -58,6 +62,7 @@
 {{end}}
 {{$numArgs:= len $args}}
 
+{{/*Exec can be called 5 times max, so $selectedArgs will have up to 5 $args to be processed*/}}
 {{$selectedArgs:= cslice}}
 {{if gt $numArgs 5}}
 	{{$selectedArgs = slice $args 0 5}}
@@ -69,25 +74,32 @@
 	{{$selectedArgs = $args}}
 {{end}}
 
+{{/*Process each selected argument in this execution*/}}
 {{range $selectedArgs}}
+	{{/*EXECute "-cc" and extract stuff from its output*/}}
 	{{- $answer:= exec "cc" .}}
 	{{- $answerLines:= split $answer "\n"}}
 	{{- $extractedCode:= slice $answerLines 2 (sub (len $answerLines) 1)}}
 	{{- $firstLine:= index $answerLines 0}}
 
+	{{/*Check if Answer's $firstLine is actually an error message*/}}
 	{{- if in $firstLine "here is a list of"}}
 		{{- sendMessage nil (printf "❌ CC `%s` not found" .)}}
 	{{- else if in $firstLine "More than 1 matched command"}}
+		{{/*Insert argument in message output, and if it's empty, replace it with "<Empty trigger specified>"*/}}
 		{{- $msj:= reReplace "``" (printf "`%s`: %s" . $answer) "`<Empty trigger specified>`"}}
-		{{- template "sendLongMessage" (cslice nil $msj "\n")}}
+		{{- template "sendLongMessage" (sdict "channelID" nil "text" $msj "separator" "\n")}}
 	{{- else}}
+		{{/*No error message, so send CC's code and info*/}}
 		{{- $content:= ""}}
-		{{- $attachment:= (joinStr "\n" $extractedCode)}}
+		{{- $attachment:= joinStr "\n" $extractedCode}}
 
+		{{/*If $CCInfo_MessageContent flag is set, the info will be sent as message content*/}}
 		{{- if $CCInfo_MessageContent}}
 			{{- $content = $firstLine}}
 		{{- end}}
 
+		{{/*If $CCInfo_Attachment flag is set, the info will be a comment in message's attachment*/}}
 		{{- if $CCInfo_Attachment}}
 			{{- $attachment = printf "{{/* CC INFO: %s */}}\n\n%s" $firstLine $attachment}}
 		{{- end}}
@@ -100,9 +112,11 @@
 
 	{{- sleep 1}}
 {{else}}
-	{{template "sendLongMessage" (cslice nil (exec "cc") "\n")}}
+	{{/*If there are 0 args, send full CC list*/}}
+	{{template "sendLongMessage" (sdict "channelID" nil "text" (exec "cc") "separator" "\n")}}
 {{end}}
 
+{{/*If $limitTo5CCs flag is not set, and there are still arguments left, execute CC again to process them*/}}
 {{if and (not $limitTo5CCs) (gt $numArgs 5)}}
 	{{scheduleUniqueCC .CCID nil 1 "cc2file - remaining args" (slice $args 5 $numArgs)}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -4,26 +4,48 @@
 	
 	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "te st" 23`
 	Recommended trigger: Command trigger with trigger `cc2file`.
-	Configuration variables: None
+	Configuration variables: $limitTo5CCs, $CCInfo_MessageContent, $CCInfo_Attachment
 */}}
 
+{{/* CONFIGURATION AREA STARTS */}}
+	{{$limitTo5CCs:= true}}				{{/*If `true`, bot will do that. Prevents flood in the chat*/}}
+	{{$CCInfo_MessageContent:= true}}		{{/*If `true`, the info of each CC will be included in the message content*/}}
+	{{$CCInfo_Attachment:= false}}			{{/*If `true`, the info of each CC will be included in the attached file*/}}
+{{/* CONFIGURATION AREA ENDS */}}
 
 {{define "sendLongMessage"}}	{{/*INPUT: cslice channelIDToSend textToSend stringSeparator*/}}
 	{{$channelID:= index . 0}} {{$text:= index . 1}} {{$separator:= index . 2}}
 	{{$outStr:= ""}}
 
-	{{ range (split $text $separator)}}
+	{{range (split $text $separator)}}
 		{{- if gt (add (len $outStr) (len .)) 2000}}
 			{{- sendMessage $channelID $outStr}}
 			{{- $outStr = .}}
 		{{- else}}
-			{{- $outStr = (joinStr $separator $outStr .)}}
+			{{- $outStr = joinStr $separator $outStr .}}
 		{{- end -}}
-	{{ end}}
+	{{end}}
+
 	{{sendMessage $channelID $outStr}}
 {{end}}
 
-{{$args:= cslice}} {{$selectedArgs:= cslice}}
+{{define "sendLongMessageV2"}}	{{/*INPUT: sdict "channelID" $ID "text" $Text "separator" $Sepr*/}}
+	{{$outStr:= ""}}
+
+	{{range (split .text .separator)}}
+		{{- if gt (add (len $outStr) (len .)) 2000}}
+			{{- sendMessage .channelID $outStr}}
+			{{- $outStr = .}}
+		{{- else}}
+			{{- $outStr = joinStr .separator $outStr .}}
+		{{- end -}}
+	{{end}}
+
+	{{sendMessage .channelID $outStr}}
+{{end}}
+
+
+{{$args:= cslice}}
 {{with .ExecData}}
 	{{$args = .}}
 {{else}}
@@ -35,8 +57,13 @@
 {{end}}
 {{$numArgs:= len $args}}
 
+{{$selectedArgs:= cslice}}
 {{if gt $numArgs 5}}
 	{{$selectedArgs = slice $args 0 5}}
+
+	{{if $limitTo5CCs}}
+		{{sendMessage nil "⚠️ WARNING: Only first 5 CCs will be processed"}}
+	{{end}}
 {{else}}
 	{{$selectedArgs = $args}}
 {{end}}
@@ -53,15 +80,26 @@
 		{{- $msj:= reReplace "``" (printf "`%s`: %s" . $answer) "`<Empty trigger specified>`"}}
 		{{- template "sendLongMessage" (cslice nil $msj "\n")}}
 	{{- else}}
+		{{- $content:= ""}}
+		{{- $attachment:= (joinStr "\n" $extractedCode)}}
+
+		{{- if $CCInfo_MessageContent}}
+			{{- $content = $firstLine}}
+		{{- end}}
+
+		{{- if $CCInfo_Attachment}}
+			{{- $attachment = printf "{{/* CC INFO: %s */}}\n\n%s" $firstLine $attachment}}
+		{{- end}}
+
 		{{- sendMessage nil (complexMessage
-			"content" $firstLine
-			"file" (joinStr "\n" $extractedCode)
+			"content" $content
+			"file" $attachment
 		)}}
 	{{- end}}
 {{else}}
 	{{template "sendLongMessage" (cslice nil (exec "cc") "\n")}}
 {{end}}
 
-{{if gt $numArgs 5}}
+{{if and (not $limitTo5CCs) (gt $numArgs 5)}}
 	{{scheduleUniqueCC .CCID nil 1 "cc2file - remaining args" (slice $args 5 $numArgs)}}
 {{end}}

--- a/util/cc2file.go.tmpl
+++ b/util/cc2file.go.tmpl
@@ -2,9 +2,10 @@
 	This command sends your CC(s) code in a text file, rather than "plain" Discord messages, preserving Tabs, markdown, etc. 
 	You can especify more than one ID or trigger, and bot will generate one file per input parameter. If none are provided, output will be CC list
 	
+	Recommended trigger: "cc2file"
+	Trigger type: Command
+	
 	Usage: `-cc2file <ID or Trigger> [ID or Trigger] [ID or Trigger]...`. For example: `-cc2file 10 "te st" 23`
-	Recommended trigger: Command trigger with trigger `cc2file`.
-	Configuration variables: $limitTo5CCs, $CCInfo_MessageContent, $CCInfo_Attachment
 */}}
 
 {{/* CONFIGURATION AREA STARTS */}}
@@ -96,6 +97,8 @@
 			"file" $attachment
 		)}}
 	{{- end}}
+
+	{{- sleep 1}}
 {{else}}
 	{{template "sendLongMessage" (cslice nil (exec "cc") "\n")}}
 {{end}}


### PR DESCRIPTION
## **Please describe the changes this PR makes and why it should be merged:**
This update brings some features:
- Ability to limit execution to 5 CCs
- Ability to show/hide the info of each CC, in message's content and/or attachment's content (it's inserted as a comment)²
- Ability to blacklist CCs to maintain its code private¹

And some minor changes:
- `sendLongMessage` template now uses an `sdict` rather than a `cslice`
- Heavily-commented code: This is mostly for people who has to troubleshoot my code, if there are problems in a future

## **Status**
I didn't really test every single combination of options, but yeah, it works ;)

Some improvements that can be done:
1. Allow some users/roles to override blacklist?
2. Parse `$firstLine`'s content, extract CC info and print it in a format similar to this repo's Leading comments. Something like:
```go
//Before:
{{/* CC INFO: #20 - Contains: `viva` - Case sensitive trigger: `false` - Group: `Respuestas` */}}

//After:
{{/*
	Description:
	Usage:³

	Trigger type: Contains
	Recommended trigger: "viva"
	Case sensitive trigger: "false"

	Credits:
*/}}
```
- In that case, I'll need help with Regex. I'll probably ask in YAG's support server
3. In exported code, if `parseArgs` is used at least one time, copy the `Custom usage text when invalid args provided` argument to the `Usage:` field?
- An easier alternative is replace ` - ` with `\n\t`, so basic output now has some indentation. Something like:
```go
//Before:
{{/* CC INFO: #20 - Contains: `viva` - Case sensitive trigger: `false` - Group: `Respuestas` */}}

//After:
{{/* CC INFO:
	ID #20 
	Contains: `viva`
	Case sensitive trigger: `false`
	Group: `Respuestas`
*/}}
```


- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
