### PR TITLE
Message to Embed Converter

### DIFF
--- a/messagetoembed/converter
+++ b/messagetoembed/converter
@@ -1,0 +1,24 @@
+{{ $channel :=  }} {{/* Replace this with your suggestion channel ID */}}
+
+{{if .Message.Attachments}}
+		{{ $embed := cembed
+			"title"  "Photo"
+			"description" (index .Message.Content)
+			"timestamp"  currentTime
+			"image"  (sdict "url" (index .Message.Attachments 0).URL)
+		}}
+		{{ $id := (sendMessageNoEscapeRetID $channel $embed) }}
+		{{ addMessageReactions $channel $id "1️⃣" "2️⃣" "3️⃣" "4️⃣" }}
+		{{deleteResponse 5}}
+		{{deleteTrigger 5}}
+{{else}}
+	{{ $embed := cembed
+		"description"  (index .Message.Content)
+		"color" 9021952
+		"timestamp"  currentTime
+	}}
+	{{ $id := (sendMessageNoEscapeRetID $channel $embed) }}
+	{{ addMessageReactions $channel $id "1️⃣" "2️⃣" "3️⃣" "4️⃣" }}
+	{{deleteResponse 5}}
+	{{deleteTrigger 5}}
+{{end}}


### PR DESCRIPTION
### Short explanation
This is a little command that I made for use in a Discord server. It uses some code from the example commands, but what this does is it identifies the contents of the message, and based on that, it either contains the attachment (image) from the message and the text, or it contains the text only if there are no attachments.
I believe it could be useful if tidied up, to be part of the example custom commands.
### Trigger
The trigger for this custom command is _Regex_ **.***
### Optimization
This might require a lot of changes or there are better ways to do this, but I couldn't find an example that would convert any message to an embed regardless if it was an image, or text, or text and image.
### Prospects
I believe the future of this could be a command that can be used in a private channel to configure in which channels is it used, what emojis are used, and perhaps even scheduling, if we were to go all-in. 

**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
