### PR TITLE
New RAID GUARD System

### DIFF
--- a/util/Raid Guard/raidadmin.go.templ
+++ b/util/Raid Guard/raidadmin.go.templ
@@ -1,0 +1,106 @@
+{{/*
+	Trigger: raid
+	Trigger Type: Command
+
+	About: This code was created in response to a raid that was done on a server that I am an admin. Over 100 people raided the server, and started sending messages, 
+	DMing people. It took us admins atleast 30 min to realized that all these people were from all one raid, as we hadnt been pinged, or notified. Thats when i came up with
+	this idea of a monitoring system. This system will oversee all incoming members, if that member has an account that is younger than a certain age (1 day default), then
+	they will be added to a database list. If that list reaches a certain amount of people (25 ppl default) within 10 min, then it will send a notification to the modlog.
+	
+	This notification will alert the admin (or a role of your choosing), and ask if they would like to kick/ban all of the RAID members at once. An option has also been 
+	provided to manually reset the raid list. The program will run through the entire list and remove all raiders for good.
+
+	Created by: ENGINEER15 - https://github.com/engineer152/
+	Last Update: 4/13/2021
+*/}}
+
+{{$t := "" }}
+{{$cc := toInt .CCID }}
+{{$l := cslice}}
+{{$thumb := (sdict "url" "https://cdn.discordapp.com/emojis/714051544265392229.gif")}}
+{{$qlen := 0}}
+
+{{$q:=cslice}}
+{{with (dbGet 0 "raidlist").Value}}
+    {{$q =$q.AppendSlice .}}{{end}}
+{{$nq:=cslice}}
+{{range $i,$e:=$q}}
+    {{if $i}}
+        {{$nq =$nq.Append $e}}
+    {{end}}
+{{end}}
+
+{{with .CmdArgs}}
+    {{$t = index . 0}}{{end}} 
+{{with (dbGet 0 "raidlist").Value}}
+    {{$l = $l.AppendSlice . }}{{end}}
+{{$qlen = len $l}}
+
+{{$embed := sdict 
+	"title" " 🛡 RAID GUARD"
+	"description" "*Initializing in 3...*"
+	"color" 14232643
+    "thumbnail" $thumb }}
+
+{{$channel := .Channel.ID }}
+{{$user := "" }}
+
+{{with .ExecData }}
+    {{$embed = sdict .Embed }}
+    {{$qlen = .Qlen }}
+    {{$data := sdict . }}
+    {{$thumb := "" }}
+    {{$command := .Command}}
+   	{{ $msgs := split $embed.description "\n" | cslice.AppendSlice }}
+    {{$title := split $embed.title "\n" | cslice.AppendSlice }}
+	{{$msgs = cslice }}{{ $title = cslice }}
+    {{if $q}}
+        {{with (index $q 0) }}
+            {{$user = . }}{{end}}
+        {{if eq $command "kick"}}
+            {{$k := execAdmin (printf "kick %d For being part of a RAID" $user.ID ) }}
+        {{else if eq $command "ban"}}
+            {{$k := execAdmin (printf "ban %d For being part of a RAID" $user.ID ) }}
+        {{end}}
+        {{if not (eq (len $nq) 0) }}
+            {{$title = $title.Append (print "👢 REMOVING ALL RAID MEMBERS" )}}
+            {{$msgs = $msgs.Append (printf "Currently Removing: %s" $user.Username )}}
+		    {{$thumb = (sdict "url" "https://cdn.discordapp.com/emojis/714051544265392229.gif")}}
+            {{dbSet 0 "raidlist" $nq}}
+            {{execCC $cc $channel 2 $data }}
+        {{else}}
+            {{$title = $title.Append (print "**✅ COMPLETE**" )}}
+            {{$msgs = $msgs.Append (printf "ALL %d RAIDERS HAVE BEEN REMOVED.\nYour server has been protected by**🛡 RAID GUARD.**" $qlen )}}
+            {{$thumb = (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png")}}
+		    {{dbDel 0 "raidlist"}}
+        {{end}}
+    {{else}}
+        {{$thumb = (sdict "url" "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/281/person-shrugging_1f937.png")}}
+        {{$title = $title.Append (print "\n" )}}
+        {{$msgs = $msgs.Append (print "❌ THE RAIDLIST IS EMPTY\n\nNo RAID has happened recently. 👍" )}}
+    {{end}}
+    {{$embed.Set "title" (joinStr "\n" $title.StringSlice ) }}
+    {{$embed.Set "description" (joinStr "\n" $msgs.StringSlice ) }}
+    {{$embed.Set "thumbnail" $thumb }}
+    {{$data.Set "Embed" $embed }}
+    {{editMessage .ChannelID .MsgID (cembed $embed) }}
+
+{{else}}
+    
+    {{if eq $t "clear"}}
+        {{dbDel 0 "raidlist"}}
+        {{$embed2 := sdict 
+	        "title" "✅ COMPLETE"
+	        "description" "🧹 RAID LIST HAS NOW BEEN CLEARED"
+	        "color" 14232643 }}
+        {{sendMessage nil (cembed $embed2) }}
+    {{else if or (eq $t "kick") (eq $t "ban")}}
+        {{$initial := sendMessageRetID nil (cembed $embed) }}
+        {{sleep 3 }}
+        {{execCC $cc (.Channel.ID) 0 (sdict
+	        "Embed" $embed
+	        "MsgID" $initial
+	        "ChannelID" .Channel.ID
+            "Qlen" $qlen
+            "Command" $t)}}
+    {{end}}{{end}}

--- a/util/Raid Guard/raidjoin.go.templ
+++ b/util/Raid Guard/raidjoin.go.templ
@@ -1,0 +1,52 @@
+{{/*
+	Trigger: member join
+	This code is to be placed in the "Join Message" section.
+
+	About: This code was created in response to a raid that was done on a server that I am an admin. Over 100 people raided the server, and started sending messages, 
+	DMing people. It took us admins atleast 30 min to realized that all these people were from all one raid, as we hadnt been pinged, or notified. Thats when i came up with
+	this idea of a monitoring system. This system will oversee all incoming members, if that member has an account that is younger than a certain age (1 day default), then
+	they will be added to a database list. If that list reaches a certain amount of people (25 ppl default) within 10 min, then it will send a notification to the modlog.
+	
+	This notification will alert the admin (or a role of your choosing), and ask if they would like to kick/ban all of the RAID members at once. An option has also been 
+	provided to manually reset the raid list. The program will run through the entire list and remove all raiders for good.
+
+	Created by: ENGINEER15 - https://github.com/engineer152/
+	Last Update: 4/13/2021
+*/}}
+
+{{$age := 1440}} {{/*New account age in minutes 1440 = one day*/}}
+{{$len := 25}}{{/*Number of new members in a raid to be notified by*/}}
+{{$newmem := .User }}
+{{$l:=cslice}}
+
+{{with (dbGet 0 "raidlist").Value}}
+    {{$l = $l.AppendSlice . }}{{end}}
+
+{{ if not (dbGet 0 "raidlistcool")}}
+    {{dbDel 0 "raidlist"}}{{end}}
+
+{{define "alert"}}
+    {{$rolemention := cslice (mentionRoleID 830118239211487273) }} {{/*This will be the role that gets pinged. MAKE SURE YOU CHANGE OUT THE ID WITH YOURS!*/}}
+    {{$channel := 830118169812926464 }} {{/*Channel ID for modlog*/}}
+    {{$embed := cembed 
+        "title" " ⚠ RAID ALERT!" 
+        "description" "I have determined that there are more than:\n**25 BRAND NEW ACCOUNTS**\nthat just joined the server!\n\n__Options:__\n1. `-raid kick` - Kicks all raid members.\n2. `-raid ban` - Bans all raid members.\n3. `-raid clear` - Clear Raid List"
+        "color" (randInt 16777217)
+        "thumbnail" (sdict "url" "https://cdn.discordapp.com/emojis/565142262401728512.png" )}}
+    {{sendMessageNoEscape $channel (complexMessage "content" $rolemention "embed" $embed) }}
+{{end}}
+
+{{if lt (currentUserAgeMinutes) $age}}
+	{{if not (dbGet $newmem "raidcooldown") }}
+        {{$l = $l.Append $newmem}}
+        {{dbSet 0 "raidlist" $l}}
+        {{if eq (len $l) $len}}
+            {{template "alert" 1}}
+        {{end}}
+        {{dbSetExpire $newmem "raidcooldown" true 3600}}
+        {{dbSetExpire 0 "raidlistcool" true 1200 }}
+	    {{if eq (len $l) 50}}
+		    {{execAdmin "lockdown -all -force" }}
+        {{end}}
+    {{end}}
+{{end}}


### PR DESCRIPTION
This code was created in response to a raid that was done on a server that I am an admin. Over 100 people raided the server, and started sending messages, DMing people. It took us admins at least 30 min to realized that all these people were from all one raid, as we hadn't been pinged, or notified. That's when I came up with this idea of a monitoring system. This system will oversee all incoming members, if that member has an account that is younger than a certain age (1 day default), then they will be added to a database list. If that list reaches a certain amount of people (25 ppl default) within 10 min, then it will send a notification to the modlog. This notification will alert the admin (or a role of your choosing), and ask if they would like to kick/ban all of the RAID members at once. An option has also been  provided to manually reset the raid list. The program will run through the entire list and remove all raiders for good.

**Status**

- [X] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [X] I have read and followed the [contribution guide](../CONTRIBUTING.md)
