### PR TITLE
changed google emojis to twemojis

### DIFF
--- a/util/bigemoji.go.tmpl
+++ b/util/bigemoji.go.tmpl
@@ -8,7 +8,7 @@
 	{{ $embed := sdict }} {{ $emoji := index .CmdArgs 0 }}
 		{{ if reFind `\p{So}|.\x{20e3}` $emoji }}
 			{{ $emoji_U := "" }}
-			{{ $url := "https://raw.githubusercontent.com/iamcal/emoji-data/master/img-google-136/" }}
+			{{ $url := "https://raw.githubusercontent.com/iamcal/emoji-data/master/img-twitter-64/" }}
 			{{- range toRune $emoji }}
 				{{- $emoji_U = joinStr "-" $emoji_U (printf "%04x" .) }}
 			{{- end -}}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

updated the bigemoji command to not use the google emoji pack, but use the twemoji pack which represents the discord emojis

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
