### PR TITLE
Style/website docs and learn link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -102,12 +102,12 @@ module.exports = {
 						},
 						{
 							label: 'Documentation',
-							to: 'https://docs.yagpdb.xyz'
+							to: 'https://docs.yagpdb.xyz',
 						},
 						{
 							label: 'Learning Center',
-							to: 'https://learn.yagpdb.xyz'
-						}
+							to: 'https://learn.yagpdb.xyz',
+						},
 					],
 				},
 				{

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -118,7 +118,7 @@ module.exports = {
 							href: 'https://github.com/jonas747/yagpdb',
 						},
 						{
-							label: 'YAGPDB Discord',
+							label: 'YAGPDB Community Discord',
 							href: 'https://discord.com/invite/4udtcA5',
 						},
 					],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -100,17 +100,25 @@ module.exports = {
 							label: 'YAGPDB CCs',
 							to: '/',
 						},
+						{
+							label: 'Documentation',
+							to: 'https://docs.yagpdb.xyz'
+						},
+						{
+							label: 'Learning Center',
+							to: 'https://learn.yagpdb.xyz'
+						}
 					],
 				},
 				{
 					title: 'Community',
 					items: [
 						{
-							label: 'YAGPDB Github',
+							label: 'YAGPDB Source',
 							href: 'https://github.com/jonas747/yagpdb',
 						},
 						{
-							label: 'Discord',
+							label: 'YAGPDB Discord',
 							href: 'https://discord.com/invite/4udtcA5',
 						},
 					],


### PR DESCRIPTION
**Summary:**
This pull request adds one link each pointing to the learning centre as well as the documentation to the footer under the "Docs" section.
Additionally, it will also reword the labels `YAGPDB GitHub` to `YAGPDB Source` and `Discord` to `YAGPDB Discord`.

**Reasoning:**
Seeing as the footer looked a little bit empty to me, I thought this might be worthwhile, especially considering the fact that people should consult the documentation and the learning course before adding custom commands - having these links in as many places as possible should help regarding this.

Moreover, I find "YAGPDB GitHub" quite non-descriptive - it's the source repository, so it should be labelled as such. Same for "Discord"; It's the Discord-Server focused around YAGPDB, so "YAGPDB Discord" is quite justified.

**Status:**
- [x] No major code changes that need deep review