### PR TITLE
leveling/moderation/utils/website: review getChannel usage

### DIFF
--- a/src/leveling/leveling.go.tmpl
+++ b/src/leveling/leveling.go.tmpl
@@ -19,9 +19,9 @@
 }}
 {{ if .CmdArgs }}
 	{{ $isSaved := false }} {{/* Whether the settings are saved */}}
-	{{ $currentSettings := sdict 
-		"min" 15 
-		"max" 25 
+	{{ $currentSettings := sdict
+		"min" 15
+		"max" 25
 		"cooldown" .TimeMinute
 			"announcements" true
 	}} {{/* Defaults for level settings */}}
@@ -33,7 +33,7 @@
 	{{ if eq (index .CmdArgs 0) "use-default" }}
 		{{ $s := dbSet 0 "xpSettings" $currentSettings }} {{/* Set defaults */}}
 		Done! You are now using the default settings for the leveling system.
-	
+
 	{{ else if and (eq (index .CmdArgs 0) "set") (ge (len .CmdArgs) 3) }}
 		{{ $key := index .CmdArgs 1 }} {{/* The key of the setting being set */}}
 		{{ $value := slice .CmdArgs 2 | joinStr " " }} {{/* The value of the new setting */}}
@@ -57,7 +57,7 @@
 	{{ else if and (eq (index .CmdArgs 0) "set-channel") (ge (len .CmdArgs) 2) }}
 		{{ $input := index .CmdArgs 1 }}
 		{{ with reFindAllSubmatches `<#(\d+)>` $input }} {{ $input = toInt64 (index . 0 1) }} {{ end }}
-		{{ $channel := getChannel $input }}
+		{{ $channel := .Guild.GetChannel $input }}
 		{{ if $channel }}
 			{{ $currentSettings.Set "channel" $channel.ID }}
 			{{ $s := dbSet 0 "xpSettings" $currentSettings }}
@@ -90,7 +90,7 @@
 		{{ $formatted := printf "**❯ Minimum XP:** %d\n**❯ Maximum XP:** %d\n**❯ Cooldown:** %s\n**❯ Level-up Channel:** %s\n**❯ Announcements:** %v\n"
 			$currentSettings.min
 			$currentSettings.max
-			(humanizeDurationSeconds ($currentSettings.cooldown | toDuration)) 
+			(humanizeDurationSeconds ($currentSettings.cooldown | toDuration))
 			$channel
 			$currentSettings.announcements
 		}} {{/* Construct the embed description */}}
@@ -100,7 +100,7 @@
 			This server has not set up the leveling system. Run `-leveling use-default` to use the default settings or customize it using `-leveling set <key> <value>`.
 		{{ end }}
 	{{ else }} {{/* Send help messages */}}
-		{{ sendMessage nil $helpMsg }} 
+		{{ sendMessage nil $helpMsg }}
 	{{ end }}
 {{ else }}
 	{{ sendMessage nil $helpMsg }}

--- a/src/moderation/lockdown.go.tmpl
+++ b/src/moderation/lockdown.go.tmpl
@@ -38,7 +38,7 @@
 		{{if eq (lower $channel) "nil"}} {{$channel = .Channel.ID}}
 		{{else if reFind `\d{17,19}` $channel}} {{$channel = toInt $channel}}
 		{{end}}
-		{{if getChannel $channel}}
+		{{if getChannelOrThread $channel}}
 			{{if not (reFind `^-un` (lower .Cmd))}}
 				{{if eq (len $split) 3}}
 					{{$amount := (toInt (index $split 2))}}

--- a/src/moderation/staff_on_duty.go.tmpl
+++ b/src/moderation/staff_on_duty.go.tmpl
@@ -32,7 +32,7 @@
 			{{end}}{{end}}
 		{{end}}
 		{{if $chanEdit}}
-			{{$curTopic := index (reSplit `(-\s)?Staff on duty:` (getChannel $dutyChannel).Topic) 0}}
+			{{$curTopic := index (reSplit `(-\s)?Staff on duty:` (.Guild.GetChannel $dutyChannel).Topic) 0}}
 			{{if $curTopic}}
 				{{$curTopic = print $curTopic " - Staff on duty: " $dutyList}}
 			{{else}}

--- a/src/utilities/edit.go.tmpl
+++ b/src/utilities/edit.go.tmpl
@@ -13,7 +13,7 @@
 {{$error := ""}}
 
 {{$flags := sdict "-title" "Title" "-desc" "Description" "-url" "URL" "-image" "Image" "-thumbnail" "Thumbnail" "-author" "Author" "-authoricon" "Author" "-authorurl" "Author" "-footer" "Footer" "-footericon" "Footer" "-color" "Color" "-content" "Content" "-force" "Force" "-clrembed"  "Clear"}}
-{{$subField := sdict "-image" "URL" "-thumbnail" "URL" "-author" "Name" "-authoricon" "IconURL" "-authorurl" "URL" "-footer" "Text" "-footericon" "IconURL"}} 
+{{$subField := sdict "-image" "URL" "-thumbnail" "URL" "-author" "Name" "-authoricon" "IconURL" "-authorurl" "URL" "-footer" "Text" "-footericon" "IconURL"}}
 {{$channel := .Channel}}
 {{$multipliers := cslice 1048576 65536 4096 256 16 1}}
 {{$hex2dec := sdict "A" 10 "B" 11 "C" 12 "D" 13 "E" 14 "F" 15}}
@@ -23,7 +23,7 @@
 {{if .CmdArgs}}
 	{{$channelID := ""}}
 	{{with reFindAllSubmatches `<#(\d+)>` (index .CmdArgs 0)}}{{$channelID = index . 0 1}}{{end}}
-	{{$temp := getChannel (or $channelID (index .CmdArgs 0))}}
+	{{$temp := getChannelOrThread (or $channelID (index .CmdArgs 0))}}
 	{{if $temp}}
 		{{if lt (len .CmdArgs) 3}}
 			{{$error = "Insufficient number of Args"}}
@@ -73,7 +73,7 @@
 				{{- end}}
 			{{- end}}
 		{{- end}}
-		
+
 		{{- if and (not $error) $parseFlag (not $skip)}}
 			{{- if $currentFlag}}
 				{{- if in (cslice "Description" "Title" "URL") $currentFlag}}
@@ -123,13 +123,13 @@
 
 	{{if not $error}}
 		{{if or $content (ne (print $embed) "<nil>")}}
-			{{editMessage $channel.ID $id (complexMessageEdit "content" $content "embed" $embed)}} 
+			{{editMessage $channel.ID $id (complexMessageEdit "content" $content "embed" $embed)}}
 			Done :+1:
 		{{else}}
 			{{$error = "Content and embed cannot be null at the same time."}}
 		{{end}}
 	{{end}}
-{{end}}	
+{{end}}
 
 {{if $error}}
 	{{$helpMsg.Set "description" (print "**Error** - `" $error  "`\n" ($helpMsg.Get "description"))}}

--- a/src/utilities/json.go.tmpl
+++ b/src/utilities/json.go.tmpl
@@ -17,7 +17,7 @@
 {{ $mainMessage := sendMessageRetID nil (cembed "description" "Converting Message... <a:loading:760219029620523008>") }}
 
 {{ if ne ($a.Get 0) "0" }}
-	{{ $chan = getChannel (or (reFind `\d+` ($a.Get 0)) ($a.Get 0)) }}
+	{{ $chan = getChannelOrThread (or (reFind `\d+` ($a.Get 0)) ($a.Get 0)) }}
 
 	{{ with $chan }} {{ $link = joinStr "/" "https://discordapp.com/channels" $.Guild.ID .ID ($a.Get 1) }}
 	{{ else }} {{ $ce = false }}

--- a/src/utilities/send.go.tmpl
+++ b/src/utilities/send.go.tmpl
@@ -28,7 +28,7 @@
 	{{- if eq . "-description"}} {{$description = true}} {{else if in $flags .}} {{$description = false}} {{end -}}
 	{{- if and ($description) (not (eq . "-description"))}} {{$isEmbed = true}} {{$descriptionV = joinStr " " $descriptionV .}} {{end -}}
 	{{- if eq . "-channel"}} {{$channel = true}} {{else if in $flags .}} {{$channel = false}} {{end -}}
-	{{- if and ($channel) (not (eq . "-channel"))}} {{$checkChannel := reReplace `<|>|#` . ""}} {{with getChannel $checkChannel}} {{$channelV = .ID}} {{end}} {{end -}}
+	{{- if and ($channel) (not (eq . "-channel"))}} {{$checkChannel := reReplace `<|>|#` . ""}} {{with getChannelOrThread $checkChannel}} {{$channelV = .ID}} {{end}} {{end -}}
 	{{- if eq . "-title"}} {{$title = true}} {{else if in $flags .}} {{$title = false}} {{end -}}
 	{{- if and ($title) (not (eq . "-title"))}} {{$isEmbed = true}} {{$titleV = joinStr " " $titleV .}} {{end -}}
 	{{- if eq . "-image"}} {{$image = true}} {{else if in $flags .}} {{$image = false}} {{end -}}

--- a/website/src/custom-languages/prism-gotmpl/funcs.js
+++ b/website/src/custom-languages/prism-gotmpl/funcs.js
@@ -93,6 +93,7 @@ export const funcs = [
 	'deleteMessageReaction',
 	'getMember',
 	'getChannel',
+	'getChannelOrThread',
 	'reFindAll',
 	'addRoleName',
 	'scheduleUniqueCC',


### PR DESCRIPTION
The current implementation of `getChannel` may throw an error, which is
generally undesirable. This commit audits the usage of said function
and, depending on case, opts to use `.Guild.GetChannel` or
`getChannelOrThread`.

In cases where an actual, solid channel is needed, `.Guild.GetChannel`
is to be used, otherwise `getChannelOrThread`.

Closes yagpdb-cc/yagpdb-cc#237

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
- [x] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
