### PR TITLE
docs(birthday#overview): Edit a phrase

### DIFF
--- a/website/docs/birthday/overview.md
+++ b/website/docs/birthday/overview.md
@@ -43,7 +43,7 @@ Before your birthday custom command is ready to go, you still need to configure 
   Date format to use. If set to to `true`, YAGPDB will use the american notation `mm/dd/yyyy` instead of `dd/mm/yyyy`.
 
 - `$yearOptional`<br />
-  Whether the year is optional when configuring birthdays; set to `true` to enable. This will make the year default to `2000`, should a member not give a year upon configuring their birthday.
+  Whether the year is optional when configuring birthdays; set to `true` to enable. This will make the year default to `2000`, if a member does not give a year upon configuring their birthday.
 
 - `$kickUnderAge`<br />
   Whether to kick users younger than 13 years old; set to `true` to enable.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Hi! I was adding that CC to my server, until I've read [docs for `$yearOptional`](https://yagpdb-cc.github.io/birthday/overview#list-of-configurable-values). English is not my native language, so I didn't originally understand this:
> [...] should a member not give a year upon configuring their birthday.

This PR gives an easier to understand phrase, at least for me

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, **or there are no code changes**
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
- [x] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, **or there is no need to**
