### PR TITLE
docs(birthday#commands): Fix missing argument for `setbirthday`

### DIFF
--- a/website/docs/birthday/overview.md
+++ b/website/docs/birthday/overview.md
@@ -80,7 +80,7 @@ All commands can be used with `bday` or `birthday`, such as `-getbday` or `-getb
   **Use:** Stops announcing birthdays immediately.
 
 - `setbirthday`<br />
-  **Syntax:** `setbirthday <user>`  
+  **Syntax:** `setbirthday <date> <user>`  
   **Use:** Set the birthday date of the mentioned user. Can only be used by users with at least one role in `$mods`.
 
 - `getbirthday`<br />


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Hi! [Here](https://yagpdb-cc.github.io/birthday/overview#commands) the documented syntax is `setbirthday <user>`, but when running the command, `parseArgs` says
> Correct syntax is: `-setbday date @user`

**Status**

- [X] Code changes have been tested on an instance of YAGPDB, **or there are no code changes**
- [X] I have read and followed the [contribution guide](../CONTRIBUTING.md)
- [X] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, **or there is no need to**
