### PR TITLE
repo(pr_template): Fix broken URLs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,4 @@
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
 - [ ] I have read and followed the [contribution guide](../CONTRIBUTING.md)
 - [ ] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+[test](.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,3 @@
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
 - [ ] I have read and followed the [contribution guide](../CONTRIBUTING.md)
 - [ ] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
-      [test](.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](../blob/master/CONTRIBUTING.md)
-- [ ] I have [written documentation](../blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
+- [ ] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
 - [ ] I have read and followed the [contribution guide](../CONTRIBUTING.md)
 - [ ] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
-[test](.)
+      [test](.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](/CONTRIBUTING.md)
-- [ ] I have [written documentation](/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](../CONTRIBUTING.md)
+- [ ] I have [written documentation](/../../WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](../CONTRIBUTING.md)
-- [ ] I have [written documentation](/../../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](../blob/documented)
+- [ ] I have [written documentation](../blob/documented/WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](../blob/documented/CONTRIBUTING.md)
-- [ ] I have [written documentation](../blob/documented/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](../blob/master/CONTRIBUTING.md)
+- [ ] I have [written documentation](../blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](CONTRIBUTING.md)
-- [ ] I have [written documentation](WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](/CONTRIBUTING.md)
+- [ ] I have [written documentation](/WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](../CONTRIBUTING.md)
-- [ ] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](CONTRIBUTING.md)
+- [ ] I have [written documentation](WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](../blob/documented)
-- [ ] I have [written documentation](../blob/documented/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](/MatiasMFM2001/yagpdb-my-ccs/blob/documented/CONTRIBUTING.md)
+- [ ] I have [written documentation](/MatiasMFM2001/yagpdb-my-ccs/blob/documented/WRITING-DOCUMENTATION.md) for my changes, or there is no need to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@
 **Status**
 
 - [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
-- [ ] I have read and followed the [contribution guide](/MatiasMFM2001/yagpdb-my-ccs/blob/documented/CONTRIBUTING.md)
-- [ ] I have [written documentation](/MatiasMFM2001/yagpdb-my-ccs/blob/documented/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
+- [ ] I have read and followed the [contribution guide](../blob/documented/CONTRIBUTING.md)
+- [ ] I have [written documentation](../blob/documented/WRITING-DOCUMENTATION.md) for my changes, or there is no need to


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #265. Currently, GitHub does weird stuff with relative links on PRs, so this may break again in the future
If you go to "real" `PULL_REQUEST_TEMPLATE.md` file, URLs won't work. But they do if you open a PR

Just in case: [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) [`WRITING-DOCUMENTATION.md`](../blob/master/WRITING-DOCUMENTATION.md)

PS: Sorry for shitty commit names

**Status**

- [X] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [X] I have read and followed the [contribution guide](../CONTRIBUTING.md)
- [X] I have [written documentation](../WRITING-DOCUMENTATION.md) for my changes, or there is no need to
