### PR TITLE
Update CCs to use .ServerPrefix

### DIFF
--- a/src/afk/afk.go.tmpl
+++ b/src/afk/afk.go.tmpl
@@ -10,9 +10,9 @@
 {{ $removeAfkOnMessage := true}}
 {{/* End of configurable values */}}
 
-{{ $time := 0 }}{{ $afk := dbGet .User.ID "afk" }}{{ $prefix := .ServerPrefix }}{{ $desc := "" }}
+{{ $time := 0 }}{{ $afk := dbGet .User.ID "afk" }}{{ $desc := "" }}
 {{ if $args := .Args }}
-	{{ if eq (lower (index $args 0)) (print $prefix "afk") }}
+	{{ if eq (lower (index $args 0)) (print .ServerPrefix "afk") }}
 		{{ if and (ge (len $args) 1) (not $afk) }}
 			{{ $message := "" }}
 			{{ $duration := 0 }}

--- a/src/afk/afk.go.tmpl
+++ b/src/afk/afk.go.tmpl
@@ -10,7 +10,7 @@
 {{ $removeAfkOnMessage := true}}
 {{/* End of configurable values */}}
 
-{{ $time := 0 }}{{ $afk := dbGet .User.ID "afk" }}{{ $prefix := index (reFindAllSubmatches `.*?: \x60(.*)\x60\z` (execAdmin "Prefix")) 0 1 }}{{ $desc := "" }}
+{{ $time := 0 }}{{ $afk := dbGet .User.ID "afk" }}{{ $prefix := .ServerPrefix }}{{ $desc := "" }}
 {{ if $args := .Args }}
 	{{ if eq (lower (index $args 0)) (print $prefix "afk") }}
 		{{ if and (ge (len $args) 1) (not $afk) }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -13,7 +13,7 @@
 {{ $cooldown := 5 }}
 {{/* Configuration variables end */}}
 
-{{ $prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1 }}{{ $cp := "" }}{{ $m := 0 }}{{ $bet := "" }}{{ $err := false }}{{ $img := "https://cdn.discordapp.com/attachments/707661790443733022/782710794634264616/d74906d39a1964e7d07555e7601b06ad.gif" }}{{ $cap := "https://cdn.discordapp.com/attachments/707661790443733022/782713935341027358/cap.png" }}{{ $pajura := "https://cdn.discordapp.com/attachments/707661790443733022/782713937979637760/pajura.png" }}{{ $embed:= sdict }}{{ $fields := cslice }}{{ $embed.Set "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256"))}}
+{{ $prefix := .ServerPrefix }}{{ $cp := "" }}{{ $m := 0 }}{{ $bet := "" }}{{ $err := false }}{{ $img := "https://cdn.discordapp.com/attachments/707661790443733022/782710794634264616/d74906d39a1964e7d07555e7601b06ad.gif" }}{{ $cap := "https://cdn.discordapp.com/attachments/707661790443733022/782713935341027358/cap.png" }}{{ $pajura := "https://cdn.discordapp.com/attachments/707661790443733022/782713937979637760/pajura.png" }}{{ $embed:= sdict }}{{ $fields := cslice }}{{ $embed.Set "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256"))}}
 {{ if not .ExecData }}
 	{{ if eq (len .CmdArgs) 2 }}
 		{{ with reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -13,7 +13,7 @@
 {{ $cooldown := 5 }}
 {{/* Configuration variables end */}}
 
-{{ $prefix := .ServerPrefix }}{{ $cp := "" }}{{ $m := 0 }}{{ $bet := "" }}{{ $err := false }}{{ $img := "https://cdn.discordapp.com/attachments/707661790443733022/782710794634264616/d74906d39a1964e7d07555e7601b06ad.gif" }}{{ $cap := "https://cdn.discordapp.com/attachments/707661790443733022/782713935341027358/cap.png" }}{{ $pajura := "https://cdn.discordapp.com/attachments/707661790443733022/782713937979637760/pajura.png" }}{{ $embed:= sdict }}{{ $fields := cslice }}{{ $embed.Set "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256"))}}
+{{ $cp := "" }}{{ $m := 0 }}{{ $bet := "" }}{{ $err := false }}{{ $img := "https://cdn.discordapp.com/attachments/707661790443733022/782710794634264616/d74906d39a1964e7d07555e7601b06ad.gif" }}{{ $cap := "https://cdn.discordapp.com/attachments/707661790443733022/782713935341027358/cap.png" }}{{ $pajura := "https://cdn.discordapp.com/attachments/707661790443733022/782713937979637760/pajura.png" }}{{ $embed:= sdict }}{{ $fields := cslice }}{{ $embed.Set "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256"))}}
 {{ if not .ExecData }}
 	{{ if eq (len .CmdArgs) 2 }}
 		{{ with reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}
@@ -67,7 +67,7 @@
 			{{ $err = true }}
 		{{ end }}
 	{{ else }}
-		{{ $embed.Set "description" (printf "Syntax: **%scoinflip <heads/tails> <money>**" $prefix) }}
+		{{ $embed.Set "description" (printf "Syntax: **%scoinflip <heads/tails> <money>**" .ServerPrefix) }}
 		{{ $embed.Set "color" 16488706 }}
 		{{ $err = true }}
 	{{ end }}

--- a/src/fun/counting.go.tmpl
+++ b/src/fun/counting.go.tmpl
@@ -21,7 +21,7 @@
 
 {{/* CODE - Don't edit this part */}}
 {{ $c := sdict }}{{ with (dbGet 20 "counting").Value }}{{ $c = sdict . }}{{ end }}
-{{ $e := execAdmin "prefix" }}{{ $p := reReplace `[*\\_\~]` (slice $e (add 15 (len (str .Guild.ID))) (sub (len $e) 1)) `\$0` }}
+{{ $p := .ServerPrefix }}
 {{ $r := 0 }}{{ with (dbGet .User.ID "resetcount").Value }}{{ $r = . }}{{ end }}
 {{ $s := false }}{{ range .Member.Roles }}{{ if in $staff_roles . }}{{ $s = true }}{{ end }}{{ end }}
 {{ if not $c }}

--- a/src/fun/counting.go.tmpl
+++ b/src/fun/counting.go.tmpl
@@ -21,14 +21,13 @@
 
 {{/* CODE - Don't edit this part */}}
 {{ $c := sdict }}{{ with (dbGet 20 "counting").Value }}{{ $c = sdict . }}{{ end }}
-{{ $p := .ServerPrefix }}
 {{ $r := 0 }}{{ with (dbGet .User.ID "resetcount").Value }}{{ $r = . }}{{ end }}
 {{ $s := false }}{{ range .Member.Roles }}{{ if in $staff_roles . }}{{ $s = true }}{{ end }}{{ end }}
 {{ if not $c }}
 	{{ addReactions "☑" }}
 	{{ dbSet 20 "counting" (sdict "l" (sdict "c" 1 "m" 0 "u" 0 "w" 0)) }}
 	{{ print .User.Mention ", <#" .Channel.ID "> is all set up as your counting channel!" }}
-{{ else if and $s (eq (print $p "resetcount") .Message.Content) }}
+{{ else if and $s (eq (print .ServerPrefix "resetcount") .Message.Content) }}
 	{{ deleteTrigger 1 }}
 	{{ if $s }}
 		{{ if not $r }}

--- a/src/moderation/nickname_moderation.go.tmpl
+++ b/src/moderation/nickname_moderation.go.tmpl
@@ -12,7 +12,7 @@
 {{/* End of configurable values */}}
 
 {{$mod := in (split (index (split (exec "viewperms") "\n") 2) ", ") $modPerms}}
-{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
+{{$prefix := .ServerPrefix}}
 {{if .CmdArgs}}
 	{{if eq (lower (index .CmdArgs 0)) (print $prefix "modnick")}}
 		{{if ge (len .CmdArgs) 2}}

--- a/src/moderation/report_system/cancel_report.go.tmpl
+++ b/src/moderation/report_system/cancel_report.go.tmpl
@@ -6,9 +6,7 @@
 */}}
 
 {{/*ACTUAL CODE*/}}
-{{$p := index (reFindAllSubmatches `.*?: \x60(.*)\x60\z` (execAdmin "prefix")) 0 1}}
-{{$Escaped_Prefix := reReplace `[\.\[\]\-\?\!\\\*\{\}\(\)\|\+]` $p `\${0}`}}
-{{if not (reFind (print `\A` $Escaped_Prefix `|<@!?204255221017214977>`) .Message.Content)}}
+{{if not (reFind (print `\A` .ServerPrefix `|<@!?204255221017214977>`) .Message.Content)}}
 Did not set regex to match Server Prefix! {{deleteTrigger}}
 {{else}}
 {{if lt (len .CmdArgs) 3}}

--- a/src/moderation/report_system/custom_report.go.tmpl
+++ b/src/moderation/report_system/custom_report.go.tmpl
@@ -11,9 +11,7 @@
 {{/* End of configurable values */}}
 
 {{/* ACTUAL CODE */}}
-{{$p := index (reFindAllSubmatches `.*?: \x60(.*)\x60\z` (execAdmin "prefix")) 0 1}}
-{{$Escaped_Prefix := reReplace `[\.\[\]\-\?\!\\\*\{\}\(\)\|\+]` $p `\${0}`}}
-{{if not (reFind (print `\A` $Escaped_Prefix `|<@!?204255221017214977>`) .Message.Content)}}
+{{if not (reFind (print `\A` .ServerPrefix `|<@!?204255221017214977>`) .Message.Content)}}
 Did not set regex to match Server Prefix!{{deleteTrigger}}
 {{else}}
 {{if and .CmdArgs (lt (len .CmdArgs) 2)}}

--- a/src/suggestion/suggestion.go.tmpl
+++ b/src/suggestion/suggestion.go.tmpl
@@ -17,15 +17,14 @@
 {{/* End of configurable values */}}
 
 {{$globalDict:=dict "chans" (dict $Suggestion_Channel true $Approved_Channel true $Implemented_Channel true) "msg" .nil}}
-{{$Prefix:=index (reFindAllSubmatches `.*?: \x60(.*)\x60\z` (execAdmin "Prefix")) 0 1}}
-{{$Escaped_Prefix:=reReplace `[\$\^\.\[\]\-\?\!\\\*\{\}\(\)\|\+]` $Prefix `\${0}`}}
+{{$Prefix:=.ServerPrefix}}
 {{$error:=""}}
 {{$Syntax:=""}}
 {{$IS_Mod:=false}}
 {{if in (slice (exec "viewperms") (add 25 (len .User.Username))) `Administrator`}}{{$IS_Mod =true}}{{else}}{{range $Mod_Roles}}{{if in $.Member.Roles .}}{{$IS_Mod =true}}{{end}}{{end}}{{end}}
 {{$Attachments:=""}}{{$Img_Set:=false}}
 
-{{if not (reFind (print `\A` $Escaped_Prefix `|<@!?204255221017214977>`) .Message.Content)}}{{$error ="Did not set regex to match Server Prefix"}}{{$Syntax =`Prefix/Yag Mention <Command> <Args>`}}{{else}}
+{{if not (reFind (print `\A` $Prefix `|<@!?204255221017214977>`) .Message.Content)}}{{$error ="Did not set regex to match Server Prefix"}}{{$Syntax =`Prefix/Yag Mention <Command> <Args>`}}{{else}}
 {{if reFind `(?i)\bsuggest(ion)?\b` .Cmd}}
 	{{$Syntax =print .Cmd " <Suggestion_Here>"}}
 	{{$col:=16777215}}{{$pos:=0}}{{$r:=.Member.Roles}}{{range .Guild.Roles}}{{if and (in $r .ID) (.Color) (lt $pos .Position)}}{{$pos =.Position}}{{$col =.Color}}{{end}}{{end}}	
@@ -58,7 +57,7 @@
 	{{$authorID:=0}}{{$message:=.nil}}{{$channel:=.nil}}{{$rest:=""}}{{$command:=""}}{{$type:=""}}{{$SNum:=0}}
 	{{$Syntax =print .Cmd " <Suggestion_ID> <Message/Arguments>"}}
 
-	{{with reFindAllSubmatches (print `(?si)\A(?:` $Escaped_Prefix `\s?|\S+\s*)(?:(del|edit)\w+|\w+\s+(\w+))\s+(\d+)\s*(.*)`) .Message.Content}}
+	{{with reFindAllSubmatches (print `(?si)\A(?:` $Prefix `\s?|\S+\s*)(?:(del|edit)\w+|\w+\s+(\w+))\s+(\d+)\s*(.*)`) .Message.Content}}
 		{{$command =lower (or (index . 0 1) (index . 0 2))}}
 		{{$mID:=index . 0 3}}
 		{{$rest =index . 0 4}}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`.ServerPrefix` removes the need for having to index with `exec "prefix"` that many of these CCs use. Also just saves few more chars.

Small Note: I did not feel the birthday CC required this change as it does not specifically check if it's the server's prefix, only getting the prefix used to run the CC.

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
