### PR TITLE
Replace usages of viewperms

### DIFF
--- a/src/moderation/nickname_moderation.go.tmpl
+++ b/src/moderation/nickname_moderation.go.tmpl
@@ -8,10 +8,10 @@
 {{/* Configurable values */}}
 {{$name := "Moderated Nickname"}}
 {{$padding := "5"}}
-{{$modPerms := "ManageMessages"}}
+{{$modPerms := .Permissions.ManageMessages}}
 {{/* End of configurable values */}}
 
-{{$mod := in (split (index (split (exec "viewperms") "\n") 2) ", ") $modPerms}}
+{{$mod := hasPermissions $modPerms}}
 {{$prefix := .ServerPrefix}}
 {{if .CmdArgs}}
 	{{if eq (lower (index .CmdArgs 0)) (print $prefix "modnick")}}

--- a/src/moderation/report_system/custom_report.go.tmpl
+++ b/src/moderation/report_system/custom_report.go.tmpl
@@ -17,7 +17,7 @@ Did not set regex to match Server Prefix!{{deleteTrigger}}
 {{else}}
 {{if and .CmdArgs (lt (len .CmdArgs) 2)}}
 	{{if eq (index .CmdArgs 0) "dbSetup"}}
-		{{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") "ManageServer")}}
+		{{if hasPermissions .Permissions.ManageServer}}
 			{{dbSet .Guild.ID "reportSettings" (sdict "reportLog" $REPORT_LOG "reportDiscussion" $REPORT_DISCUSSION)}}
 			{{dbSet .Guild.ID "ReportNo" 0}}
 **Database primed, report count reset, system is ready to use!**

--- a/src/moderation/report_system/reaction_handler.go.tmpl
+++ b/src/moderation/report_system/reaction_handler.go.tmpl
@@ -49,7 +49,7 @@
 {{$logs := $conf.reportLog}}
 
 {{/* Validating that it is a report message, the user a mod, parsing the author from description */}}
-{{$isMod := in (split (index (split (exec "viewperms") "\n") 2) ", ") "ManageMessages"}}
+{{$isMod := hasPermissions .Permissions.ManageMessages}}
 {{if and ($embed := (index .ReactionMessage.Embeds 0)) (eq .Channel.ID $logs)}}
 	{{$report := (index .Message.Embeds 0|structToSdict)}}
 	{{range $k, $v := $report}}{{if eq (kindOf $v true) "struct"}}{{$report.Set $k (structToSdict $v)}}{{end}}{{end}}

--- a/src/moderation/slowmode.go.tmpl
+++ b/src/moderation/slowmode.go.tmpl
@@ -6,15 +6,12 @@
 */}}
  
 {{/* Configurable values */}}
-{{ $bypassperms := "ManageMessages" }}
-{{ $usageperms := "ManageMessages" }}
+{{ $bypassperms := .Permissions.ManageMessages }}
+{{ $usageperms := .Permissions.ManageMessages }}
 {{/* End of configurable values */}}
  
 {{/* ACTUAL CODE */}}
-{{ $viewperms := (split (index (split (exec "viewperms") "\n") 2) ", ") }}
-{{ $usageaccess := in $viewperms $usageperms }}
-{{ $bypassaccess := in $viewperms $bypassperms }}
-{{ if $usageaccess }}
+{{ if hasPermissions $usageperms }}
 {{ if $matches := reFindAllSubmatches `\A-slowmode on (\d+)` .Message.Content }}
 {{ $slowmodeduration := (index $matches 0 1) }}
 {{ with (dbGet 660 "channels").Value }}
@@ -34,7 +31,7 @@ done! slowmode has been set to `{{ $slowmodeduration }}s`
 the slowmode has been removed from this channel
 {{ end }}
 {{ end }}
-{{ if not $bypassaccess }}
+{{ if not hasPermissions $bypassperms }}
 {{ if $db := (dbGet 660 "channels").Value }}
 {{ $value := sdict $db }}
 {{ $get := $value.Get (str .Channel.ID) }}

--- a/src/suggestion/suggestion.go.tmpl
+++ b/src/suggestion/suggestion.go.tmpl
@@ -21,7 +21,7 @@
 {{$error:=""}}
 {{$Syntax:=""}}
 {{$IS_Mod:=false}}
-{{if in (slice (exec "viewperms") (add 25 (len .User.Username))) `Administrator`}}{{$IS_Mod =true}}{{else}}{{range $Mod_Roles}}{{if in $.Member.Roles .}}{{$IS_Mod =true}}{{end}}{{end}}{{end}}
+{{if hasPermissions .Permissions.Administrator}}{{$IS_Mod =true}}{{else}}{{range $Mod_Roles}}{{if in $.Member.Roles .}}{{$IS_Mod =true}}{{end}}{{end}}{{end}}
 {{$Attachments:=""}}{{$Img_Set:=false}}
 
 {{if not (reFind (print `\A` $Escaped_Prefix `|<@!?204255221017214977>`) .Message.Content)}}{{$error ="Did not set regex to match Server Prefix"}}{{$Syntax =`Prefix/Yag Mention <Command> <Args>`}}{{else}}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request replaces all usages of `viewperms` with `exec` to check permissions of current user, with brand new `.Permissions` and `hasPermissions`, which [may be considered as safer and more efficient option](https://github.com/botlabs-gg/yagpdb/pull/894), and in most cases, reduces complexity as well.

**Status**

- [ ] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [ ] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [X] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
