### PR TITLE
github: bump template check action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check template syntax
-        uses: jo3-l/action-check-yag-tmpl-syntax@v2.0.1
+        uses: jo3-l/action-check-yag-tmpl-syntax@v2.0.2
         with:
           include: '**/*.go.tmpl'
 


### PR DESCRIPTION
This commit bumps the jo3-l/action-check-yag-tmpl-syntax action to its
latest release, v2.0.2.

With this change, new pipelines should no longer fail when they use new
template functions.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

----
**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
