### PR TITLE
leveling: improve leaderboard display

### DIFF
--- a/src/leveling/leaderboard.go.tmpl
+++ b/src/leveling/leaderboard.go.tmpl
@@ -15,10 +15,11 @@
 	{{ $rank := $skip }}
 	{{ $display := "" }}
 	{{ range $users }}
+	        {{- $usr := or ( and (ne .User.String "#") .User.String ) .UserID }}
 		{{- $xp := toInt .Value }}
 		{{- $rank = add $rank 1 }}
 		{{- $display = printf "%s\n• **%d.** [%s](https://yagpdb.xyz) :: Level %d (%d XP)"
-			$display $rank .User.String (toInt (roundFloor (mult 0.1 (sqrt $xp)))) $xp -}}
+			$display $rank $usr (toInt (roundFloor (mult 0.1 (sqrt $xp)))) $xp -}}
 	{{ end }}
 	{{ $id := sendMessageRetID nil (cembed
 		"title" "❯ Leaderboard"

--- a/src/leveling/leaderboard.go.tmpl
+++ b/src/leveling/leaderboard.go.tmpl
@@ -15,7 +15,10 @@
 	{{ $rank := $skip }}
 	{{ $display := "" }}
 	{{ range $users }}
-	        {{- $usr := or ( and (ne .User.String "#") .User.String ) .UserID }}
+		{{- $usr := .User.String }}
+		{{- if eq $usr "#" }}
+		    {{- $usr = .UserID }}
+		{{- end }}
 		{{- $xp := toInt .Value }}
 		{{- $rank = add $rank 1 }}
 		{{- $display = printf "%s\n• **%d.** [%s](https://yagpdb.xyz) :: Level %d (%d XP)"


### PR DESCRIPTION
This commit improves the leaderboard of the levelling system to show the
ID instead of a blank #, should they have left the server.

Closes #230

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
