### PR TITLE
website: add algolia docsearch

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,6 +52,11 @@ module.exports = {
 	projectName: 'yagpdb-cc.github.io',
 	trailingSlash: false,
 	themeConfig: {
+		algolia: {
+			appId: '8CQ0QFY0BD',
+			apiKey: 'f618121f69348e02ce793bdcb3015196',
+			indexName: 'yagpdb-cc',
+		},
 		colorMode: {
 			defaultMode: 'dark',
 			respectPrefersColorScheme: true,


### PR DESCRIPTION
This commit adds algolia's docsearch to the website frontend.

Visitors can now launch the search modal via <C-k>, which is populated
with records from algolia's crawler.

Closes #229

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
