### PR TITLE
utilities/time: defend against downtimes

### DIFF
--- a/src/utilities/time.go.tmpl
+++ b/src/utilities/time.go.tmpl
@@ -31,6 +31,17 @@
 
 {{ $marker := "night" }}
 {{ $output := exec "weather" $location }}
+
+{{ if reFind `(?i)sorry, we are running out of queries to the weather service at the moment` $output }}
+    {{ $embed := cembed
+            "title" "Error"
+            "description" "weather API is down :("
+            "color" 0xff0000
+    }}
+    {{ sendMessage nil $embed }}
+    {{ return }}
+{{ end }}
+
 {{ $output = reReplace `\x60+` $output "" }}
 {{ $res := split $output "\n" }}
 {{ $weather := slice (index $res 3) 15 }}

--- a/src/utilities/time.go.tmpl
+++ b/src/utilities/time.go.tmpl
@@ -32,7 +32,7 @@
 {{ $marker := "night" }}
 {{ $output := exec "weather" $location }}
 
-{{ if reFind `(?i)sorry, we are running out of queries to the weather service at the moment` $output }}
+{{ if inFold "sorry, we are running out of queries to the weather service at the moment" $output }}
     {{ $embed := cembed
             "title" "Error"
             "description" "weather API is down :("


### PR DESCRIPTION
Sometimes wttr.in might run out of queries, thus breaking this custom
command. This patch modifies it as such that it looks for the first line
announcing the downtime, and, if found, returns with an error stating
what happened.

Previously, the custom command simply failed, which isn't very nice UX.

Closes #263

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
