### PR TITLE
fix(slowmode): add missing parens

### DIFF
--- a/src/moderation/slowmode.go.tmpl
+++ b/src/moderation/slowmode.go.tmpl
@@ -1,46 +1,47 @@
 {{/*
 	Custom slowmode system that deletes messages that violate the slowmode time configured. Allows configuring permissions that bypass slowmode.
 	See <https://yagpdb-cc.github.io/moderation/slowmode> for more information.
- 
+
 	Author: sponge <https://github.com/Spongerooski>
 */}}
- 
+
 {{/* Configurable values */}}
 {{ $bypassperms := .Permissions.ManageMessages }}
 {{ $usageperms := .Permissions.ManageMessages }}
 {{/* End of configurable values */}}
- 
+
 {{/* ACTUAL CODE */}}
 {{ if hasPermissions $usageperms }}
-{{ if $matches := reFindAllSubmatches `\A-slowmode on (\d+)` .Message.Content }}
-{{ $slowmodeduration := (index $matches 0 1) }}
-{{ with (dbGet 660 "channels").Value }}
-{{ $value := sdict . }}
-{{ $value.Set (str $.Channel.ID) (str $slowmodeduration) }}
-{{ dbSet 660 "channels" $value }}
-{{ else }}
-{{ dbSet 660 "channels" (sdict (str $.Channel.ID) (str $slowmodeduration)) }}
+	{{ if $matches := reFindAllSubmatches `\A-slowmode on (\d+)` .Message.Content }}
+		{{ $slowmodeduration := (index $matches 0 1) }}
+		{{ with (dbGet 660 "channels").Value }}
+			{{ $value := sdict . }}
+			{{ $value.Set (str $.Channel.ID) (str $slowmodeduration) }}
+			{{ dbSet 660 "channels" $value }}
+		{{ else }}
+			{{ dbSet 660 "channels" (sdict (str $.Channel.ID) (str $slowmodeduration)) }}
+		{{ end }}
+		done! slowmode has been set to `{{ $slowmodeduration }}s`
+	{{ else if reFind `\A-slowmode off` .Message.Content }}
+		{{ if $db := (dbGet 660 "channels").Value }}
+			{{ $value := sdict $db }}
+			{{ $value.Del (str $.Channel.ID) }}
+			{{ dbSet 660 "channels" $value }}
+		{{ end }}
+		the slowmode has been removed from this channel
+	{{ end }}
 {{ end }}
-done! slowmode has been set to `{{ $slowmodeduration }}s`
-{{ else if reFind `\A-slowmode off` .Message.Content }}
-{{ if $db := (dbGet 660 "channels").Value }}
-{{ $value := sdict $db }}
-{{ $value.Del (str $.Channel.ID) }}
-{{ dbSet 660 "channels" $value }}
-{{ end }}
-the slowmode has been removed from this channel
-{{ end }}
-{{ end }}
-{{ if not hasPermissions $bypassperms }}
-{{ if $db := (dbGet 660 "channels").Value }}
-{{ $value := sdict $db }}
-{{ $get := $value.Get (str .Channel.ID) }}
-{{ if $get }}
-{{ if $slowmode := dbGet .User.ID (str .Channel.ID) }}
-{{ deleteTrigger 0 }}
-{{ else }}
-{{ dbSetExpire .User.ID (str .Channel.ID) "epic" (toInt $get) }}
-{{ end }}
-{{ end }}
-{{ end }}
+
+{{ if not (hasPermissions $bypassperms) }}
+	{{ if $db := (dbGet 660 "channels").Value }}
+		{{ $value := sdict $db }}
+		{{ $get := $value.Get (str .Channel.ID) }}
+		{{ if $get }}
+			{{ if $slowmode := dbGet .User.ID (str .Channel.ID) }}
+				{{ deleteTrigger 0 }}
+			{{ else }}
+				{{ dbSetExpire .User.ID (str .Channel.ID) "epic" (toInt $get) }}
+			{{ end }}
+		{{ end }}
+	{{ end }}
 {{ end }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes invalid syntax introduced in 6848f5682f026bc440e5e75fc34a5db49c364913
Adds indentation to improve readability

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
