### PR TITLE
docs/moderation: remove `\A` trigger from lockdown

### DIFF
--- a/website/docs/moderation/lockdown.md
+++ b/website/docs/moderation/lockdown.md
@@ -16,7 +16,7 @@ This may change in the future, but for now, this command is the closest you can 
 ## Trigger
 
 **Type:** `Regex`<br />
-**Trigger:** `\A` or `.*`
+**Trigger:** `.*`
 
 ## Usage
 


### PR DESCRIPTION
`\A` as regex trigger only tests for the start-of-line character, thus 
not populating `.Cmd`, which the custom command checks for.

This commit removes that trigger from the list.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
