### PR TITLE
Add my regionalindicatorfix for reactionlog cc

### DIFF
--- a/src/utilities/reaction_logs.go.tmpl
+++ b/src/utilities/reaction_logs.go.tmpl
@@ -21,7 +21,8 @@
 	{{- range toRune .Reaction.Emoji.Name }}
 		{{- $emoji_U = joinStr "-" $emoji_U (printf "%04x" .) }}
 	{{- end -}}
-	{{ $reaction_url = print "https://raw.githubusercontent.com/iamcal/emoji-data/master/img-google-136/" $emoji_U ".png" }}
+	{{/* Replaced original URL to fix Regional Indicators not showing in reaction log embed messages per https://github.com/successtheman/YAGPDB_reactionlog_regionalindicatorfix */}}
+	{{ $reaction_url = print "https://raw.githubusercontent.com/successtheman/YAGPDB_reactionlog_regionalindicatorfix/master/img-google-136/" $emoji_U ".png" }}
 {{end}}
 {{$addrem := "`Removed`"}}{{if .ReactionAdded}}{{$addrem = "`Added`"}}{{end}}
 

--- a/website/docs/utilities/reaction-logs.md
+++ b/website/docs/utilities/reaction-logs.md
@@ -23,3 +23,5 @@ This command logs reactions.
 ## Author
 
 This custom command was written by [@Satty9361](https://github.com/Satty9361).
+
+Regional indicator fix was done by [@SuccessTheMan](https://github.com/SuccessTheMan).


### PR DESCRIPTION

**Please describe the changes this PR makes and why it should be merged:**

This makes regional indicators (the letters used to make up flags etc... show in the reaction log embedded messages). Without this fix, when people react with them it shows no image for the emoji. I made this fix a while ago but just forgot to submit it, it should work for a while without any changes (my original fix repo is here) https://github.com/successtheman/YAGPDB_reactionlog_regionalindicatorfix

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to (documentation not needed because it is a simple one line replacement)
