### PR TITLE
docs/afk: add `.*` as possible trigger

### DIFF
--- a/website/docs/afk/main-cc.md
+++ b/website/docs/afk/main-cc.md
@@ -9,7 +9,7 @@ For more information about the AFK system, please see [this](overview) page.
 ## Trigger
 
 **Type:** `Regex`<br />
-**Trigger:** `\A`
+**Trigger:** `\A` or `.*`
 
 ## Usage
 


### PR DESCRIPTION
Add `.*` as a possible regex trigger to the list of triggers.

It works just as well.

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
