### PR TITLE
docs/moderation: remove `.*` from nickname mod

### DIFF
--- a/website/docs/moderation/nickname-moderation.mdx
+++ b/website/docs/moderation/nickname-moderation.mdx
@@ -16,7 +16,7 @@ Due to limitations for editing nicknames in YAGPDB template scripting, the offen
 ## Trigger
 
 **Type:** `Regex`<br />
-**Trigger:** `\A` or `.*`<br />
+**Trigger:** `\A`<br />
 **Additional options:** `Errors as custom command output` disabled
 
 ## Usage


### PR DESCRIPTION
Remove `.*` as regex trigger from the nickname moderation documentation, because the command checks for `.CmdArgs`, which won't be populated with a `.*` trigger.

Instead, one must use `\A`, which'll work as expected.

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
