### PR TITLE
docs: remove official remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,27 @@
 
 # Introduction
 
-A curated collection of custom commands for the [YAGPDB Discord Bot](https://yagpdb.xyz) to enhance your server. It is:
+A curated collection of custom commands for the [YAGPDB Discord Bot](https://yagpdb.xyz) to enhance your server.
+
+It is:
 
 - **Extensive:** There are over sixty custom commands (and we're adding more regularly!), meaning that it's likely that you'll be able to find what you're looking for.
-- **Official:** This collection of commands is [maintained by a group of YAGPDB staff members](#contributors) and has official support.
+- **Vetted:** This collection of commands is [maintained by a group of YAGPDB staff members](https://github.com/yagpdb-cc/yagpdb-cc#contributors).
 - **Well tested:** We review all commands added and many commands have widespread usage, meaning that it's unlikely — [though not impossible](#disclaimer) — for there to be serious bugs in them.
 - **Well documented:** We take pride in our high quality of documentation, which makes it easy for anyone to figure out how to use a command.
 
 # Disclaimer
 
-The YAGPDB developer, staff, and/or support are not responsible for any issues with or caused by these custom commands. Furthermore, though we thoroughly review all commands added, they are not guaranteed to be working; use them at your own risk.
+The YAGPDB developer, staff, and/or support are not responsible for any issues with or caused by these custom commands.
+Furthermore, though we thoroughly review all commands added, they are not guaranteed to be working; use them at your own risk.
 
 # Need help?
 
-If you are experiencing issues with a custom command from this collection, please get in touch via the [YAGPDB Support Server](https://discord.com/invite/5uVyq2E), where we can provide further assistance. If you prefer, you can also [open a GitHub Discussion](https://github.com/yagpdb-cc/yagpdb-cc/discussions).
+If you are experiencing issues with a custom command from this collection, feel free to ask on the [YAGPDB Support Server](https://discord.com/invite/5uVyq2E).
+However, do keep in mind that not every staff member knows about every custom command present.
+
+With the above in mind, a better way to get in touch might be via opening a [GitHub Discussions](https://github.com/yagpdb-cc/yagpdb-cc/discussions), as these are
+also easily searchable.
 
 If you believe you found a bug, please [open an issue](https://github.com/yagpdb-cc/yagpdb-cc/issues/new/choose).
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -23,7 +23,7 @@ The YAGPDB developer, staff, and/or support are not responsible for any issues w
 If you are experiencing issues with a custom command from this collection, feel free to ask on the [YAGPDB Support Server](https://discord.com/invite/5uVyq2E).
 However, do keep in mind that not every staff member knows about every custom command present.
 
-With the above in mind, a better way to get in touch might be via opening a [GitHub Discussions](https://github.com/yagpdb-cc/yagpdb-cc/discussions), as these are 
+With the above in mind, a better way to get in touch might be via opening a [GitHub Discussions](https://github.com/yagpdb-cc/yagpdb-cc/discussions), as these are
 also easily searchable.
 
 If you believe you found a bug, please [open an issue](https://github.com/yagpdb-cc/yagpdb-cc/issues/new/choose).

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -8,7 +8,7 @@ A curated collection of custom commands for the [YAGPDB Discord Bot](https://yag
 It is:
 
 - **Extensive:** There are over sixty custom commands (and we're adding more regularly!), meaning that it's likely that you'll be able to find what you're looking for.
-- **Official:** This collection of commands is [maintained by a group of YAGPDB staff members](#contributors) and has official support.
+- **Vetted:** This collection of commands is [maintained by a group of YAGPDB staff members](https://github.com/yagpdb-cc/yagpdb-cc#contributors).
 - **Well tested:** We review all commands added and many commands have widespread usage, meaning that it's unlikely — [though not impossible](#disclaimer) — for there to be serious bugs in them.
 - **Well documented:** We take pride in our high quality of documentation, which makes it easy for anyone to figure out how to use a given command.
 
@@ -20,7 +20,11 @@ The YAGPDB developer, staff, and/or support are not responsible for any issues w
 
 ## Need help?
 
-If you are experiencing issues with a custom command from this collection, please get in touch via the [YAGPDB Support Server](https://discord.com/invite/5uVyq2E), where we can provide further assistance. If you prefer, you can also [open a GitHub Discussion](https://github.com/yagpdb-cc/yagpdb-cc/discussions).
+If you are experiencing issues with a custom command from this collection, feel free to ask on the [YAGPDB Support Server](https://discord.com/invite/5uVyq2E).
+However, do keep in mind that not every staff member knows about every custom command present.
+
+With the above in mind, a better way to get in touch might be via opening a [GitHub Discussions](https://github.com/yagpdb-cc/yagpdb-cc/discussions), as these are 
+also easily searchable.
 
 If you believe you found a bug, please [open an issue](https://github.com/yagpdb-cc/yagpdb-cc/issues/new/choose).
 


### PR DESCRIPTION
Remove the "official" remark and replace it with the similar, but less
assertive term "vetted".

Add to the "Need help" section that not every staff may know about every
custom command present here.

The rationale behind this change is the fact that "official" implies
that all staff are more or less knowledgeable about the codebase present
in this collection, which is simply not true.
Further, it cannot be reasonably expected that all staff *are* indeed
knowledgeable about this collection.

"Vetted" has a similar meaning, though it is less assertive:
Someone with good knowledge has looked at the code and confirmed it to
be -- to the best of their abilities -- free of malicious code.

Third-party content always has a risk with it, which is also noted down
(though to a different extent) in LICENSE.md. This change should make it
clearer that whilst official staff *looked* at it, it doesn't mean that
we also serve a guarantee for it.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
