### PR TITLE
starboardv2: fix attachments not embedding

### DIFF
--- a/src/fun/starboard_v2/starboard.go.tmpl
+++ b/src/fun/starboard_v2/starboard.go.tmpl
@@ -166,7 +166,7 @@
 	{{end}}
 	{{with .ReactionMessage.Attachments}}
 		{{$attachment := (index . 0).URL}}
-		{{if reFind `\.(png|jpg|jpeg|gif|webp)$` $attachment}}
+		{{if reFind `\.(png|jpg|jpeg|gif|webp)` $attachment}}
 			{{$embed.Set "image" (sdict "url" $attachment)}}
 		{{end}}
 	{{end}}


### PR DESCRIPTION
Fix attachments not embedding properly due to no match being found.

Discord recently changed how attachment URLs are constructed[^1]. They
now have URL parameters, which the current implementation does not
account for.
Removing the constraint to match the file extension and then an EOL
reportedly fixes this issue[^2].

I decided against a more complex regex to match against the URL
parameters as well. If this causes undesirable behaviour in the future,
it is obviously subject to change.

[^1]: https://www.bleepingcomputer.com/news/security/discord-will-switch-to-temporary-file-links-to-block-malware-delivery/
[^2]: https://discord.com/channels/166207328570441728/384011387132706816/1170826121462415400

Reported-by: majorleaguebutters (Discord)
Reported-by: @FravBox

Tested-by: majorleaguebutters (Discord)
Tested-by: m0xx_ (Discord)

Thanks-to: @FravBox

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
