### PR TITLE
counting: add counting v2 command

### DIFF
--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -44,7 +44,7 @@
 {{end}}
 
 {{if ($re2:=reFindAllSubmatches (print `(?i)\A(?:-|<@!?` .BotUser.ID `>)\s*C(?:ount)?(?:ing)?Stat(?:istic)?s?\s*(?:(?:<@!?)?(\d{17,})|(l(?:eader)?b))?`) .Cmd)}}
-	{{if and (index $re2 0 1|eq "") (index $re2 0 2|eq "")}} {{/* general stats */}}
+	{{if not (or (index $re2 0 1) (index $re2 0 2))}} {{/* general stats */}}
 		{{sendMessage nil (cembed 
 			"author" (sdict 
 				"icon_url" (.Guild.IconURL "512") 

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -136,7 +136,7 @@
 		{{- $exp =printf "%s%s" $exp .}}
 		{{- if reFind `\d+` .}}
 			{{- if $lastNumeral}}
-				{{$invalid =true}}{{- break}}
+				{{- $invalid =true}}{{break}}
 			{{- end}}
 			{{- $lastNumeral =true}}
 		{{- else}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -133,7 +133,7 @@
 {{$exp:=""}}{{$lastNumeral:=false}}
 {{range $re}}
 	{{- $roman:=reFindAll `[IVXLCDM]` .}}
-	{{- if eq (len $roman) 0}}
+	{{- if not $roman}}
 		{{- $exp =printf "%s%s" $exp .}}
 		{{- if reFind `\d+` .}}
 			{{- if $lastNumeral}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -121,7 +121,7 @@
 {{end}}
 
 {{$invalid:=false}}
-{{$re:=reFindAll `\b([%e]|abs|pi)(\b|$)|[+\-*/^π()]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|\d+|[MDCLXVI]M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
+{{$re:=reFindAll `\b([%e]|abs|pi)(\b|$)|[+\-*/^π()]|a?(sin|cos|tan|cot|sec|csc)|sqrt|l(o?g|n)|\d+|[MDCLXVI]M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
 {{if not (joinStr "" $re)}}
 	{{return}}
 {{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -20,23 +20,23 @@
 {{ $leaderboardLength := 10 }} {{/* how many members to show on leaderboard; max of 100 */}}
 {{/* end of configurable values */}}
 
-{{$db:=or 
-	(dbGet 0 "counting").Value 
+{{$db:=or
+	(dbGet 0 "counting").Value
 	(sdict "last" (sdict "user" .BotUser.ID "msg" 0) "next" 1 "highscore" (sdict "user" .BotUser.ID "num" 0 "time" currentTime) "saves" $saves)
 }}
 
 {{with .ExecData}}
 	{{$msg:=getMessage nil .}}
 	{{if not $msg}} {{/* check if message was deleted */}}
-		{{sendMessage nil (cembed 
-			"description" (printf "<@%d> deleted their expression which was correct!\nThe next number is %d" 
+		{{sendMessage nil (cembed
+			"description" (printf "<@%d> deleted their expression which was correct!\nThe next number is %d"
 				$db.last.user $db.next
-			) 
+			)
 			"color" 30654
 		)}}
 	{{else if $msg.EditedTimestamp}} {{/* check if message was edited */}}
-		{{sendMessage nil (cembed 
-			"description" (printf "<@%d> edited their expression, be careful" $db.last.user) 
+		{{sendMessage nil (cembed
+			"description" (printf "<@%d> edited their expression, be careful" $db.last.user)
 			"color" 30654
 		)}}
 	{{end}}
@@ -45,18 +45,18 @@
 
 {{if ($re2:=reFindAllSubmatches (print `(?i)\A(?:-|<@!?` .BotUser.ID `>)\s*C(?:ount)?(?:ing)?Stat(?:istic)?s?\s*(?:(?:<@!?)?(\d{17,})|(l(?:eader)?b))?`) .Cmd)}}
 	{{if not (or (index $re2 0 1) (index $re2 0 2))}} {{/* general stats */}}
-		{{sendMessage nil (cembed 
-			"author" (sdict 
-				"icon_url" (.Guild.IconURL "512") 
+		{{sendMessage nil (cembed
+			"author" (sdict
+				"icon_url" (.Guild.IconURL "512")
 				"name" "🔢 Counting Statistics"
-			) 
-			"description" (printf "⌚ __Current Score__: %d\n🏅 __High Score__: %d on %v by `%s` (%d)\n⏮️ __Last Counter__: `%s` (%d)\n💾 __Saves Remaining__: %d" 
-				(sub $db.next 1) 
-				$db.highscore.num (formatTime $db.highscore.time "01/02") ($user:=userArg $db.highscore.user).Username $user.ID 
-				($user =userArg $db.last.user).Username $user.ID 
+			)
+			"description" (printf "⌚ __Current Score__: %d\n🏅 __High Score__: %d on %v by `%s` (%d)\n⏮️ __Last Counter__: `%s` (%d)\n💾 __Saves Remaining__: %d"
+				(sub $db.next 1)
+				$db.highscore.num (formatTime $db.highscore.time "01/02") ($user:=userArg $db.highscore.user).Username $user.ID
+				($user =userArg $db.last.user).Username $user.ID
 				$db.saves
-			) 
-			"footer" (sdict "text" "Use this command: -CStats [User/\"Leaderboard\"]") 
+			)
+			"footer" (sdict "text" "Use this command: -CStats [User/\"Leaderboard\"]")
 			"color" 30654
 		)}}
 		{{return}}
@@ -65,23 +65,23 @@
 	{{if ($user:=index $re2 0 1|toInt|userArg)}} {{/* user stats */}}
 		{{$userCount:=dbGet $user.ID "counting"}}
 		{{if not $userCount}}
-			{{sendMessage nil (cembed 
-				"title" (print "No available stats") 
-				"description" (printf "`%s` has yet to count ☹️\nMaybe give them a heads-up to come join?" 
+			{{sendMessage nil (cembed
+				"title" (print "No available stats")
+				"description" (printf "`%s` has yet to count ☹️\nMaybe give them a heads-up to come join?"
 					$user.Username
-				) 
-				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]") 
+				)
+				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]")
 				"color" 16711680
 			)}}
 		{{else}}
 			{{$userCount:=toInt $userCount.Value}}
 			{{$userCorrect:=(dbGet $user.ID "countingCorrect").Value}}
-			{{sendMessage nil (cembed 
-				"title" (printf "🔢 %s's Counting Statistics" $user.Username) 
-				"description" (printf "%s has counted **%d times**\n**%d** have been correct\nThis makes their average **%.2f%%**" 
+			{{sendMessage nil (cembed
+				"title" (printf "🔢 %s's Counting Statistics" $user.Username)
+				"description" (printf "%s has counted **%d times**\n**%d** have been correct\nThis makes their average **%.2f%%**"
 					$user.Mention $userCount (toInt $userCorrect) (div $userCorrect $userCount|mult 100.0)
-				) 
-				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]") 
+				)
+				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]")
 				"color" 30654
 			)}}
 		{{end}}
@@ -91,20 +91,20 @@
 		{{range $i,$v:=dbTopEntries "countingCorrect" $leaderboardLength 0}}
 			{{- $desc =printf "%s\n#%-3d %4d - %-4s" $desc (add $i 1) (toInt $v.Value) (or (userArg $v.UserID) (str $v.UserID)) -}}
 		{{end}}
-		{{sendMessage nil (cembed 
-			"author" (sdict 
-				"icon_url" (.Guild.IconURL "512") 
+		{{sendMessage nil (cembed
+			"author" (sdict
+				"icon_url" (.Guild.IconURL "512")
 				"name" "Counting Leaderboard"
-			) 
-			"description" (printf "```Pos    ✅  User%s```" $desc) 
-			"footer" (sdict "text" "Use this command: -CStats Leaderboard") 
+			)
+			"description" (printf "```Pos    ✅  User%s```" $desc)
+			"footer" (sdict "text" "Use this command: -CStats Leaderboard")
 			"color" 30654
 		)}}
 
 	{{else}}
-		{{sendMessage nil (cembed 
-			"title" "Invalid Syntax" 
-			"description" "For server counting statistics: `-CStats`\nFor a members' statistics: `-CStats <User: @/ID>`\nFor server leaderboard: `-CStats Leaderboard`" 
+		{{sendMessage nil (cembed
+			"title" "Invalid Syntax"
+			"description" "For server counting statistics: `-CStats`\nFor a members' statistics: `-CStats <User: @/ID>`\nFor server leaderboard: `-CStats Leaderboard`"
 			"color" 16744192
 		)}}
 	{{end}}
@@ -112,8 +112,8 @@
 {{end}}
 
 {{if and (eq $db.last.user .User.ID) (not $countTwice)}}
-	{{sendMessage nil (cembed 
-		"description" (printf "You can't count twice in a row 🥲\nThe next number is %d" $db.next) 
+	{{sendMessage nil (cembed
+		"description" (printf "You can't count twice in a row 🥲\nThe next number is %d" $db.next)
 		"color" 16744192
 	)}}
 	{{return}}
@@ -177,8 +177,8 @@
 {{catch}}{{$invalid =true}}{{end}}
 
 {{if $invalid}}
-	{{sendMessage nil (cembed 
-		"description" (printf "`%s` sent an invalid expression, `%s`\nNext number is `%d`" .User.Username .Cmd $db.next) 
+	{{sendMessage nil (cembed
+		"description" (printf "`%s` sent an invalid expression, `%s`\nNext number is `%d`" .User.Username .Cmd $db.next)
 		"color" 16711680
 	)}}
 	{{return}}
@@ -206,8 +206,8 @@
 		{{takeRoleID $db.last.user .}}
 		{{addRoleID .}}
 	{{end}}
-	{{$db.Set "last" (sdict 
-		"user" .User.ID 
+	{{$db.Set "last" (sdict
+		"user" .User.ID
 		"msg" .Message.ID
 	)}}
 
@@ -242,14 +242,14 @@
 		{{end}}
 		{{$db.Set "last" (sdict "user" .User.ID "msg" .Message.ID)}}
 		{{dbSet 0 "counting" $db}}
-		{{sendMessage nil (cembed 
-			"description" (printf "%s sent an incorrect number of %d\n**But**, the count was saved! %d saves remaining\nThe next number is %d" .User.Username $number $db.saves $db.next) 
+		{{sendMessage nil (cembed
+			"description" (printf "%s sent an incorrect number of %d\n**But**, the count was saved! %d saves remaining\nThe next number is %d" .User.Username $number $db.saves $db.next)
 			"color" 16744192
 		)}}
 
 	{{else}} {{/* reset count */}}
-		{{sendMessage nil (cembed 
-			"description" (printf "%s sent an incorrect number of %d\nCorrect number was %d\nStart over at 1 🙃" .User.Mention $number $db.next) 
+		{{sendMessage nil (cembed
+			"description" (printf "%s sent an incorrect number of %d\nCorrect number was %d\nStart over at 1 🙃" .User.Mention $number $db.next)
 			"color" 16711680
 		)}}
 		{{$db.Set "last" (sdict "user" .BotUser.ID "msg" 0)}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -87,10 +87,9 @@
 		{{end}}
 
 	{{else if eq (index $re2 0 2|lower) "leaderb" "lb"}} {{/* leaderboard */}}
-		{{$desc:=""}}{{$pos:=1}}
-		{{range dbTopEntries "countingCorrect" $leaderboardLength 0}}
-			{{- $desc =printf "%s\n#%-3d %4d - %-4s" $desc $pos (toInt .Value) (or (userArg .UserID) (str .UserID))}}
-			{{- $pos =add $pos 1 -}}
+		{{$desc:=""}}
+		{{range $i,$v:=dbTopEntries "countingCorrect" $leaderboardLength 0}}
+			{{- $desc =printf "%s\n#%-3d %4d - %-4s" $desc (add $i 1) (toInt $v.Value) (or (userArg $v.UserID) (str $v.UserID)) -}}
 		{{end}}
 		{{sendMessage nil (cembed 
 			"author" (sdict 

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -122,7 +122,7 @@
 
 {{$invalid:=false}}
 {{$re:=reFindAll `\b([%e]|abs|pi)(\b|$)|[+\-*/^π()]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|\d+|[MDCLXVI]M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
-{{if eq (joinStr "" $re) ""}}
+{{if not (joinStr "" $re)}}
 	{{return}}
 {{end}}
 {{if ne .Cmd (joinStr "" $re)}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -1,11 +1,9 @@
 {{/*
 	Count up from 1 using base 10 and/or roman numerals with availability of math
-		View counting statistics with the -cstats command
-		See https://github.com/ei14/calc#supported-functions-operators-and-constants for math functionality
+	View counting statistics with the -cstats command
+	See <https://github.com/ei14/calc#supported-functions-operators-and-constants> for math functionality
 	
-	Regex: .+
-	
-	Restrict to counting channel
+	See <https://yagpdb-cc.github.io/fun/counting_v2> for more information.
 	
 	Author: H1nr1 <https://github.com/H1nr1>
 */}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -121,7 +121,10 @@
 {{end}}
 
 {{$invalid:=false}}
-{{$re:=reFindAll `[+\-*/^%]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
+{{$re:=reFindAll `\b([%e]|abs|pi)(\b|$)|[+\-*/^π()]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|\d+|[MDCLXVI]M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}`{{json $re}}`
+{{if eq (joinStr "" $re) ""}}
+	{{return}}
+{{end}}
 {{if ne .Cmd (joinStr "" $re)}}
 	{{$invalid =true}}
 {{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -15,9 +15,9 @@
 {{ $reactions := true }} {{/* allow confirmative reactions on message; true/false */}}
 	{{ $reactionDelete := true }} {{/* toggle for reactions to delete from last message; true/false */}}
 	{{ $correctEmoji := "✅" }} {{/* emoji to react with if number is correct; if custom, use format name:id */}}
-	{{ $warningEmoji := "⚠️" }} {{/* emoji to react with if wrong number AND Second Chance is true/on; if custom, use format name:id */}}
+	{{ $warningEmoji := "⚠️" }} {{/* emoji to react with if wrong number with available saves; if custom, use format name:id */}}
 	{{ $incorrectEmoji := "❌" }} {{/* emoji to react with if number is incorrect; if custom, use format name:id */}}
-{{ $leaderboardLength := 10 }} {{/* how many members to show on leaderboard; MAX OF 100 */}}
+{{ $leaderboardLength := 10 }} {{/* how many members to show on leaderboard; max of 100 */}}
 {{/* end of configurable values */}}
 
 {{$db:=or 

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -121,7 +121,7 @@
 {{end}}
 
 {{$invalid:=false}}
-{{$re:=reFindAll `\b([%e]|abs|pi)(\b|$)|[+\-*/^π()]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|\d+|[MDCLXVI]M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}`{{json $re}}`
+{{$re:=reFindAll `\b([%e]|abs|pi)(\b|$)|[+\-*/^π()]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|\d+|[MDCLXVI]M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
 {{if eq (joinStr "" $re) ""}}
 	{{return}}
 {{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -1,0 +1,272 @@
+{{/*
+	Count up from 1 using base 10 and/or roman numerals with availability of math
+		View counting statistics with the -cstats command
+		See https://github.com/ei14/calc#supported-functions-operators-and-constants for math functionality
+	
+	Regex: .+
+	
+	Restrict to counting channel
+	
+	Author: H1nr1 <https://github.com/H1nr1>
+*/}}
+
+{{/* configurable values */}}
+{{ $countTwice := false }} {{/* allow users to count multiple times in a row; true/false */}}
+{{ $correctRID := false }} {{/* correct counting role ID; set to false to disable */}}
+{{ $incorrectRID := false }} {{/* incorrect/blacklist counting role ID; set to false to disable */}}
+{{ $errorCID := .Channel.ID }} {{/* ID of channel to send error reports to; .Channel.ID for current channel */}}
+{{ $saves := 1 }} {{/* how many wrong numbers before reset; set to 0 for no saves */}}
+{{ $reactions := true }} {{/* allow confirmative reactions on message; true/false */}}
+	{{ $reactionDelete := true }} {{/* toggle for reactions to delete from last message; true/false */}}
+	{{ $correctEmoji := "✅" }} {{/* emoji to react with if number is correct; if custom, use format name:id */}}
+	{{ $warningEmoji := "⚠️" }} {{/* emoji to react with if wrong number AND Second Chance is true/on; if custom, use format name:id */}}
+	{{ $incorrectEmoji := "❌" }} {{/* emoji to react with if number is incorrect; if custom, use format name:id */}}
+{{ $leaderboardLength := 10 }} {{/* how many members to show on leaderboard; MAX OF 100 */}}
+{{/* end of configurable values */}}
+
+{{$db:=or 
+	(dbGet 0 "counting").Value 
+	(sdict "last" (sdict "user" .BotUser.ID "msg" 0) "next" 1 "highscore" (sdict "user" .BotUser.ID "num" 0 "time" currentTime) "saves" $saves)
+}}
+
+{{with .ExecData}}
+	{{$msg:=getMessage nil .}}
+	{{if not $msg}} {{/* check if message was deleted */}}
+		{{sendMessage nil (cembed 
+			"description" (printf "%s deleted their expression which was correct!\nThe next number is %d" 
+				(userArg $db.last.user).Mention $db.next
+			) 
+			"color" 30654
+		)}}
+	{{else if $msg.EditedTimestamp}} {{/* check if message was edited */}}
+		{{sendMessage nil (cembed 
+			"description" (printf "%s edited their expression, be careful" (userArg $db.last.user).Mention) 
+			"color" 30654
+		)}}
+	{{end}}
+	{{return}}
+{{end}}
+
+{{if ($re2:=reFindAllSubmatches (print `(?i)\A(?:-|<@!?` .BotUser.ID `>)\s*C(?:ount)?(?:ing)?Stat(?:istic)?s?\s*(?:(?:<@!?)?(\d{17,})|(l(?:eader)?b))?`) .Cmd)}}
+	{{if and (index $re2 0 1|eq "") (index $re2 0 2|eq "")}} {{/* general stats */}}
+		{{sendMessage nil (cembed 
+			"author" (sdict 
+				"icon_url" (.Guild.IconURL "512") 
+				"name" "🔢 Counting Statistics"
+			) 
+			"description" (printf "⌚ __Current Score__: %d\n🏅 __High Score__: %d on %v by `%s` (%d)\n⏮️ __Last Counter__: `%s` (%d)\n💾 __Saves Remaining__: %d" 
+				(sub $db.next 1) 
+				$db.highscore.num (formatTime $db.highscore.time "01/02") (userArg $db.highscore.user).Username (userArg $db.highscore.user).ID 
+				(userArg $db.last.user).Username (userArg $db.last.user).ID 
+				$db.saves
+			) 
+			"footer" (sdict "text" "Use this command: -CStats [User/\"Leaderboard\"]") 
+			"color" 30654
+		)}}
+		{{return}}
+	{{end}}
+
+	{{if ($user:=index $re2 0 1|toInt|userArg)}} {{/* user stats */}}
+		{{$userCount:=dbGet $user.ID "counting"}}
+		{{if not $userCount}}
+			{{sendMessage nil (cembed 
+				"title" (print "No available stats") 
+				"description" (printf "`%s` has yet to count ☹️\nMaybe give them a heads-up to come join?" 
+					$user.Username
+				) 
+				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]") 
+				"color" 16711680
+			)}}
+		{{else}}
+			{{$userCount:=toInt $userCount.Value}}
+			{{$userCorrect:=(dbGet $user.ID "countingCorrect").Value|toInt}}
+			{{sendMessage nil (cembed 
+				"title" (printf "🔢 %s's Counting Statistics" $user.Username) 
+				"description" (printf "%s has counted **%d times**\n**%d** have been correct\nThis makes their average **%.2f%%**" 
+					$user.Mention $userCount $userCorrect (div (toFloat $userCorrect) $userCount|mult 100.0)
+				) 
+				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]") 
+				"color" 30654
+			)}}
+		{{end}}
+
+	{{else if eq (index $re2 0 2|lower) "leaderb" "lb"}} {{/* leaderboard */}}
+		{{$desc:=""}}{{$pos:=1}}
+		{{range dbTopEntries "countingCorrect" $leaderboardLength 0}}
+			{{- $desc =printf "%s\n#%-3d %4d - %-4s" $desc $pos (toInt .Value) (or (userArg .UserID) (str .UserID))}}
+			{{- $pos =add $pos 1 -}}
+		{{end}}
+		{{sendMessage nil (cembed 
+			"author" (sdict 
+				"icon_url" (.Guild.IconURL "512") 
+				"name" "Counting Leaderboard"
+			) 
+			"description" (printf "```Pos    ✅  User%s```" $desc) 
+			"footer" (sdict "text" "Use this command: -CStats Leaderboard") 
+			"color" 30654
+		)}}
+
+	{{else}}
+		{{sendMessage nil (cembed 
+			"title" "Invalid Syntax" 
+			"description" "For server counting statistics: `-CStats`\nFor a members' statistics: `-CStats <User: @/ID>`\nFor server leaderboard: `-CStats Leaderboard`" 
+			"color" 16744192
+		)}}
+	{{end}}
+	{{return}}
+{{end}}
+
+{{if and (eq $db.last.user .User.ID) (not $countTwice)}}
+	{{sendMessage nil (cembed 
+		"description" (printf "You can't count twice in a row 🥲\nThe next number is %d" $db.next) 
+		"color" 16744192
+	)}}
+	{{return}}
+{{end}}
+
+{{$re:=reFindAll `\+|\-|\*|\/|\^|\%|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
+{{if ne .Cmd (joinStr "" $re)}}
+	{{sendMessage nil (cembed 
+		"description" (printf "`%s` sent an invalid expression, `%s`\nNext number is `%d`" .User.Username .Cmd $db.next) 
+		"color" 16711680
+	)}}
+	{{return}}
+{{end}}
+
+{{$convertRN:=sdict "I" 1 "V" 5 "X" 10 "L" 50 "C" 100 "D" 500 "M" 1000}}
+{{$exp:=""}}{{$lastRN:=false}}
+{{range $re}}
+	{{- $roman:=reFindAll `I|V|X|L|C|D|M` .}}
+	{{- if eq (len $roman) 0}}
+		{{- $exp =printf "%s%s" $exp .}}
+		{{- $lastRN =false}}
+		{{- continue}}
+	{{- end}}
+	{{- if $lastRN}}
+		Invalid Expression. Please try again
+		{{- return}}
+	{{- end}}
+	{{- $values:=cslice}}{{- $value:=0}}{{- $skip:=false}}
+	{{- range $roman}}
+		{{- $values =$values.Append ($convertRN.Get .) -}}
+	{{- end}}
+	{{- range $i,$v:=$values}}
+		{{- $i =add $i 1}}
+		{{- if $skip}}
+			{{- $skip =false}}
+			{{- continue}}
+		{{- end}}
+		{{- if le (len $values) $i}}
+			{{- $value =add $value .}}
+			{{- continue}}
+		{{- end}}
+		{{- if ge . (index $values $i)}}
+			{{- $value =add $value .}}
+		{{- else}}
+			{{- $value =sub (add $value (index $values $i)) .}}
+			{{- $skip =true}}
+		{{- end -}}
+	{{- end}}
+	{{- $exp =printf "%s%d" $exp $value}}
+	{{- $lastRN =true}}
+{{end}}
+
+{{$number:=0}}
+{{try}}{{$number =slice ($number =exec "calc" $exp) 9 (len $number|add -1)|toFloat|toInt}}
+{{catch}}{{.}}; Invalid Expression. Please try again{{return}}{{end}}
+
+{{if eq $db.next $number}} {{/* correct */}}
+	{{$db.Set "next" (add $db.next 1)}}
+	{{if $reactions}}
+		{{try}}
+			{{addReactions $correctEmoji}}
+			{{if and $reactionDelete $db.last.msg}}
+				{{deleteMessageReaction nil $db.last.msg .BotUser.ID $correctEmoji}}
+			{{end}}
+			{{if eq (mod $number 100|toInt) 0}}{{addReactions "💯"}}{{end}}
+		{{catch}}
+			{{with getRole $incorrectRID}}
+				{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+			{{end}}
+			{{sendMessage $errorCID (printf "Counting Error: `%s`\nMessage: %s\nUser: `%s` (%d)" . $.Message.Link $.User.Username $.User.ID)}}
+		{{end}}
+	{{end}}
+	{{with getRole $correctRID}}
+		{{takeRoleID $db.last.user .ID}}
+		{{addRoleID .ID}}
+	{{end}}
+	{{$db.Set "last" (sdict 
+		"user" .User.ID 
+		"msg" .Message.ID
+	)}}
+
+	{{$s:=dbIncr .User.ID "countingCorrect" 1}}
+	{{$s =dbIncr .User.ID "counting" 1}}
+	{{if gt $number $db.highscore.num}}
+		{{if $reactions}}
+			{{try}}{{addReactions "🏆"}}{{catch}}{{end}}
+		{{end}}
+		{{$db.Set "highscore" (sdict 
+			"user" .User.ID 
+			"num" $number 
+			"time" currentTime
+		)}}
+	{{end}}
+	{{dbSet 0 "counting" $db}}
+	{{execCC .CCID nil 15 .Message.ID}}
+		
+{{else}} {{/* incorrect */}}
+	{{$db.Set "saves" (sub $db.saves 1)}}
+	{{with getRole $correctRID}}
+		{{takeRoleID $db.last.user .ID}}
+	{{end}}
+	{{with getRole $incorrectRID}}
+		{{addRoleID .ID}}
+		{{(toDuration "3d").Seconds|toInt|removeRoleID .ID}}
+	{{end}}
+	{{if ge $db.saves 0}} {{/* progress saved */}}
+		{{if $reactions}}
+			{{try}}{{addReactions $warningEmoji}}
+			{{catch}}
+				{{with getRole $incorrectRID}}
+					{{addRoleID .ID}}
+					{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+				{{end}}
+				{{sendMessage $errorCID (printf "Counting Error: `%s`\nMessage: %s\nUser: %s (%d)" . $.Message.Link $.User.Username $.User.ID)}}
+			{{end}}
+		{{end}}
+		{{$db.Set "last" (sdict 
+			"user" .User.ID 
+			"msg" .Message.ID
+		)}}
+		{{dbSet 0 "counting" $db}}
+		{{sendMessage nil (cembed 
+			"description" (printf "%s sent an incorrect number of %d\n**But**, the count was saved! %d saves remaining\nThe next number is %d" .User.Username $number $db.saves $db.next) 
+			"color" 16744192
+		)}}
+
+	{{else}} {{/* reset count */}}
+		{{sendMessage nil (cembed 
+			"description" (printf "%s sent an incorrect number of %d\nCorrect number was %d\nStart over at 1 🙃" .User.Mention $number $db.next) 
+			"color" 16711680
+		)}}
+		{{$db.Set "last" (sdict 
+			"user" .BotUser.ID 
+			"msg" 0
+		)}}
+		{{$db.Set "next" 1}}
+		{{$db.Set "saves" $saves}}
+		{{dbSet 0 "counting" $db}}
+		{{$s:=dbIncr .User.ID "counting" 1}}
+		{{if $reactions}}
+			{{try}}{{addReactions $incorrectEmoji}}
+			{{catch}}
+				{{with getRole $incorrectRID}}
+					{{addRoleID .ID}}
+					{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+				{{end}}
+				{{sendMessage $errorCID (printf "Counting Error: `%s`\nMessage: %s\nUser: %s (%d)" . $.Message.Link $.User.Username $.User.ID)}}
+			{{end}}
+		{{end}}
+	{{end}}
+{{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -121,7 +121,7 @@
 {{end}}
 
 {{$invalid:=false}}
-{{$re:=reFindAll `[+-*/^%]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
+{{$re:=reFindAll `[+\-*/^%]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
 {{if ne .Cmd (joinStr "" $re)}}
 	{{$invalid =true}}
 {{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -1,7 +1,6 @@
 {{/*
 	Count up from 1 using base 10 and/or roman numerals with availability of math
 	View counting statistics with the -cstats command
-	See <https://github.com/ei14/calc#supported-functions-operators-and-constants> for math functionality
 	See <https://yagpdb-cc.github.io/fun/counting_v2> for more information.
 	
 	Author: H1nr1 <https://github.com/H1nr1>
@@ -53,8 +52,8 @@
 			) 
 			"description" (printf "⌚ __Current Score__: %d\n🏅 __High Score__: %d on %v by `%s` (%d)\n⏮️ __Last Counter__: `%s` (%d)\n💾 __Saves Remaining__: %d" 
 				(sub $db.next 1) 
-				$db.highscore.num (formatTime $db.highscore.time "01/02") (userArg $db.highscore.user).Username (userArg $db.highscore.user).ID 
-				(userArg $db.last.user).Username (userArg $db.last.user).ID 
+				$db.highscore.num (formatTime $db.highscore.time "01/02") ($user:=userArg $db.highscore.user).Username $user.ID 
+				($user =userArg $db.last.user).Username $user.ID 
 				$db.saves
 			) 
 			"footer" (sdict "text" "Use this command: -CStats [User/\"Leaderboard\"]") 
@@ -76,11 +75,11 @@
 			)}}
 		{{else}}
 			{{$userCount:=toInt $userCount.Value}}
-			{{$userCorrect:=(dbGet $user.ID "countingCorrect").Value|toInt}}
+			{{$userCorrect:=(dbGet $user.ID "countingCorrect").Value}}
 			{{sendMessage nil (cembed 
 				"title" (printf "🔢 %s's Counting Statistics" $user.Username) 
 				"description" (printf "%s has counted **%d times**\n**%d** have been correct\nThis makes their average **%.2f%%**" 
-					$user.Mention $userCount $userCorrect (div (toFloat $userCorrect) $userCount|mult 100.0)
+					$user.Mention $userCount (toInt $userCorrect) (div $userCorrect $userCount|mult 100.0)
 				) 
 				"footer" (sdict "text" "Use this command: -CStats [User: @/ID]") 
 				"color" 30654
@@ -121,31 +120,34 @@
 	{{return}}
 {{end}}
 
+{{$invalid:=false}}
 {{$re:=reFindAll `\+|\-|\*|\/|\^|\%|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
 {{if ne .Cmd (joinStr "" $re)}}
-	{{sendMessage nil (cembed 
-		"description" (printf "`%s` sent an invalid expression, `%s`\nNext number is `%d`" .User.Username .Cmd $db.next) 
-		"color" 16711680
-	)}}
-	{{return}}
+	{{$invalid =true}}
 {{end}}
 
 {{$convertRN:=sdict "I" 1 "V" 5 "X" 10 "L" 50 "C" 100 "D" 500 "M" 1000}}
-{{$exp:=""}}{{$lastRN:=false}}
+{{$exp:=""}}{{$lastNumeral:=false}}
 {{range $re}}
 	{{- $roman:=reFindAll `I|V|X|L|C|D|M` .}}
 	{{- if eq (len $roman) 0}}
 		{{- $exp =printf "%s%s" $exp .}}
-		{{- $lastRN =false}}
+		{{- if reFind `\d+` .}}
+			{{- if $lastNumeral}}
+				{{$invalid =true}}{{- break}}
+			{{- end}}
+			{{- $lastNumeral =true}}
+		{{- else}}
+			{{- $lastNumeral =false}}
+		{{- end}}
 		{{- continue}}
 	{{- end}}
-	{{- if $lastRN}}
-		Invalid Expression. Please try again
-		{{- return}}
+	{{- if $lastNumeral}}
+		{{$invalid =true}}{{- break}}
 	{{- end}}
 	{{- $values:=cslice}}{{- $value:=0}}{{- $skip:=false}}
 	{{- range $roman}}
-		{{- $values =$values.Append ($convertRN.Get .) -}}
+		{{- $values =$values.Append ($convertRN.Get .)}}
 	{{- end}}
 	{{- range $i,$v:=$values}}
 		{{- $i =add $i 1}}
@@ -162,15 +164,25 @@
 		{{- else}}
 			{{- $value =sub (add $value (index $values $i)) .}}
 			{{- $skip =true}}
-		{{- end -}}
+		{{- end}}
 	{{- end}}
 	{{- $exp =printf "%s%d" $exp $value}}
-	{{- $lastRN =true}}
+	{{- $lastNumeral =true}}
 {{end}}
 
 {{$number:=0}}
 {{try}}{{$number =slice ($number =exec "calc" $exp) 9 (len $number|add -1)|toFloat|toInt}}
-{{catch}}{{.}}; Invalid Expression. Please try again{{return}}{{end}}
+{{catch}}{{$invalid =true}}{{end}}
+
+{{if $invalid}}
+	{{sendMessage nil (cembed 
+		"description" (printf "`%s` sent an invalid expression, `%s`\nNext number is `%d`" .User.Username .Cmd $db.next) 
+		"color" 16711680
+	)}}
+	{{return}}
+{{end}}
+
+{{$errFormat:="Counting Error: `%s`\nMessage: %s\nUser: `%s` (%d)"}}
 
 {{if eq $db.next $number}} {{/* correct */}}
 	{{$db.Set "next" (add $db.next 1)}}
@@ -185,7 +197,7 @@
 			{{with getRole $incorrectRID}}
 				{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
 			{{end}}
-			{{sendMessage $errorCID (printf "Counting Error: `%s`\nMessage: %s\nUser: `%s` (%d)" . $.Message.Link $.User.Username $.User.ID)}}
+			{{sendMessage $errorCID (printf $errFormat . $.Message.Link $.User.Username $.User.ID)}}
 		{{end}}
 	{{end}}
 	{{with getRole $correctRID}}
@@ -203,11 +215,7 @@
 		{{if $reactions}}
 			{{try}}{{addReactions "🏆"}}{{catch}}{{end}}
 		{{end}}
-		{{$db.Set "highscore" (sdict 
-			"user" .User.ID 
-			"num" $number 
-			"time" currentTime
-		)}}
+		{{$db.Set "highscore" (sdict "user" .User.ID "num" $number "time" currentTime)}}
 	{{end}}
 	{{dbSet 0 "counting" $db}}
 	{{execCC .CCID nil 15 .Message.ID}}
@@ -218,24 +226,19 @@
 		{{takeRoleID $db.last.user .ID}}
 	{{end}}
 	{{with getRole $incorrectRID}}
-		{{addRoleID .ID}}
-		{{(toDuration "3d").Seconds|toInt|removeRoleID .ID}}
+		{{addRoleID .ID}}{{(toDuration "3d").Seconds|toInt|removeRoleID .ID}}
 	{{end}}
 	{{if ge $db.saves 0}} {{/* progress saved */}}
 		{{if $reactions}}
 			{{try}}{{addReactions $warningEmoji}}
 			{{catch}}
 				{{with getRole $incorrectRID}}
-					{{addRoleID .ID}}
-					{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+					{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
 				{{end}}
-				{{sendMessage $errorCID (printf "Counting Error: `%s`\nMessage: %s\nUser: %s (%d)" . $.Message.Link $.User.Username $.User.ID)}}
+				{{sendMessage $errorCID (printf $errFormat . $.Message.Link $.User.Username $.User.ID)}}
 			{{end}}
 		{{end}}
-		{{$db.Set "last" (sdict 
-			"user" .User.ID 
-			"msg" .Message.ID
-		)}}
+		{{$db.Set "last" (sdict "user" .User.ID "msg" .Message.ID)}}
 		{{dbSet 0 "counting" $db}}
 		{{sendMessage nil (cembed 
 			"description" (printf "%s sent an incorrect number of %d\n**But**, the count was saved! %d saves remaining\nThe next number is %d" .User.Username $number $db.saves $db.next) 
@@ -247,10 +250,7 @@
 			"description" (printf "%s sent an incorrect number of %d\nCorrect number was %d\nStart over at 1 🙃" .User.Mention $number $db.next) 
 			"color" 16711680
 		)}}
-		{{$db.Set "last" (sdict 
-			"user" .BotUser.ID 
-			"msg" 0
-		)}}
+		{{$db.Set "last" (sdict "user" .BotUser.ID "msg" 0)}}
 		{{$db.Set "next" 1}}
 		{{$db.Set "saves" $saves}}
 		{{dbSet 0 "counting" $db}}
@@ -259,10 +259,9 @@
 			{{try}}{{addReactions $incorrectEmoji}}
 			{{catch}}
 				{{with getRole $incorrectRID}}
-					{{addRoleID .ID}}
-					{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+					{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
 				{{end}}
-				{{sendMessage $errorCID (printf "Counting Error: `%s`\nMessage: %s\nUser: %s (%d)" . $.Message.Link $.User.Username $.User.ID)}}
+				{{sendMessage $errorCID (printf $errFormat . $.Message.Link $.User.Username $.User.ID)}}
 			{{end}}
 		{{end}}
 	{{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -29,14 +29,14 @@
 	{{$msg:=getMessage nil .}}
 	{{if not $msg}} {{/* check if message was deleted */}}
 		{{sendMessage nil (cembed 
-			"description" (printf "%s deleted their expression which was correct!\nThe next number is %d" 
-				(userArg $db.last.user).Mention $db.next
+			"description" (printf "<@%d> deleted their expression which was correct!\nThe next number is %d" 
+				$db.last.user $db.next
 			) 
 			"color" 30654
 		)}}
 	{{else if $msg.EditedTimestamp}} {{/* check if message was edited */}}
 		{{sendMessage nil (cembed 
-			"description" (printf "%s edited their expression, be careful" (userArg $db.last.user).Mention) 
+			"description" (printf "<@%d> edited their expression, be careful" $db.last.user) 
 			"color" 30654
 		)}}
 	{{end}}
@@ -121,7 +121,7 @@
 {{end}}
 
 {{$invalid:=false}}
-{{$re:=reFindAll `\+|\-|\*|\/|\^|\%|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
+{{$re:=reFindAll `[+-*/^%]|a?sin|a?cos|a?tan|a?cot|a?sec|a?csc|sqrt|l(o?g|n)|abs|e|pi|π|\(|\)|\d+|M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})` .Cmd}}
 {{if ne .Cmd (joinStr "" $re)}}
 	{{$invalid =true}}
 {{end}}
@@ -195,14 +195,14 @@
 			{{if eq (mod $number 100|toInt) 0}}{{addReactions "💯"}}{{end}}
 		{{catch}}
 			{{with getRole $incorrectRID}}
-				{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+				{{addRoleID .}}{{(toDuration "1d").Seconds|toInt|removeRoleID .}}
 			{{end}}
 			{{sendMessage $errorCID (printf $errFormat . $.Message.Link $.User.Username $.User.ID)}}
 		{{end}}
 	{{end}}
 	{{with getRole $correctRID}}
-		{{takeRoleID $db.last.user .ID}}
-		{{addRoleID .ID}}
+		{{takeRoleID $db.last.user .}}
+		{{addRoleID .}}
 	{{end}}
 	{{$db.Set "last" (sdict 
 		"user" .User.ID 
@@ -223,17 +223,17 @@
 {{else}} {{/* incorrect */}}
 	{{$db.Set "saves" (sub $db.saves 1)}}
 	{{with getRole $correctRID}}
-		{{takeRoleID $db.last.user .ID}}
+		{{takeRoleID $db.last.user .}}
 	{{end}}
 	{{with getRole $incorrectRID}}
-		{{addRoleID .ID}}{{(toDuration "3d").Seconds|toInt|removeRoleID .ID}}
+		{{addRoleID .}}{{(toDuration "3d").Seconds|toInt|removeRoleID .}}
 	{{end}}
 	{{if ge $db.saves 0}} {{/* progress saved */}}
 		{{if $reactions}}
 			{{try}}{{addReactions $warningEmoji}}
 			{{catch}}
 				{{with getRole $incorrectRID}}
-					{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+					{{addRoleID .}}{{(toDuration "1d").Seconds|toInt|removeRoleID .}}
 				{{end}}
 				{{sendMessage $errorCID (printf $errFormat . $.Message.Link $.User.Username $.User.ID)}}
 			{{end}}
@@ -259,7 +259,7 @@
 			{{try}}{{addReactions $incorrectEmoji}}
 			{{catch}}
 				{{with getRole $incorrectRID}}
-					{{addRoleID .ID}}{{(toDuration "1d").Seconds|toInt|removeRoleID .ID}}
+					{{addRoleID .}}{{(toDuration "1d").Seconds|toInt|removeRoleID .}}
 				{{end}}
 				{{sendMessage $errorCID (printf $errFormat . $.Message.Link $.User.Username $.User.ID)}}
 			{{end}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -2,7 +2,6 @@
 	Count up from 1 using base 10 and/or roman numerals with availability of math
 	View counting statistics with the -cstats command
 	See <https://github.com/ei14/calc#supported-functions-operators-and-constants> for math functionality
-	
 	See <https://yagpdb-cc.github.io/fun/counting_v2> for more information.
 	
 	Author: H1nr1 <https://github.com/H1nr1>

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -132,7 +132,7 @@
 {{$convertRN:=sdict "I" 1 "V" 5 "X" 10 "L" 50 "C" 100 "D" 500 "M" 1000}}
 {{$exp:=""}}{{$lastNumeral:=false}}
 {{range $re}}
-	{{- $roman:=reFindAll `I|V|X|L|C|D|M` .}}
+	{{- $roman:=reFindAll `[IVXLCDM]` .}}
 	{{- if eq (len $roman) 0}}
 		{{- $exp =printf "%s%s" $exp .}}
 		{{- if reFind `\d+` .}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -145,7 +145,7 @@
 		{{- continue}}
 	{{- end}}
 	{{- if $lastNumeral}}
-		{{$invalid =true}}{{- break}}
+		{{- $invalid =true}}{{break}}
 	{{- end}}
 	{{- $values:=cslice}}{{$value:=0}}{{$skip:=false}}
 	{{- range $roman}}

--- a/src/fun/counting_v2.go.tmpl
+++ b/src/fun/counting_v2.go.tmpl
@@ -147,7 +147,7 @@
 	{{- if $lastNumeral}}
 		{{$invalid =true}}{{- break}}
 	{{- end}}
-	{{- $values:=cslice}}{{- $value:=0}}{{- $skip:=false}}
+	{{- $values:=cslice}}{{$value:=0}}{{$skip:=false}}
 	{{- range $roman}}
 		{{- $values =$values.Append ($convertRN.Get .)}}
 	{{- end}}

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -8,7 +8,7 @@ A unique feature of this command is that, besides decimal numbers, it also accep
 
 Also included are statistics for the server and each user for how many times they have counted and how many times they've been correct.
 
-Messages without text are ignored by the system, effectively allowing unrelated content. However, messages including text which cannot be translated into a math expression will be quoted as invalid, but not deleted.
+Unlike some other counting systems, this command does not delete invalid numbers to allow counting and other conversation to take place concurrently. Messages that include text which do not correspond to valid numbers will, however, trigger a warning message.
 
 ## Trigger
 

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -1,0 +1,68 @@
+---
+title: Counting System
+---
+
+This command controls the counting game and the statistics command.
+
+## Trigger
+
+**Type:** `Regex`<br />
+**Trigger:** `.+`
+
+:::note Restrictions
+
+Set this command to _only run_ in your counting channel in the channel restrictions.
+
+:::
+
+## Usage
+
+- Type a number, roman numeral, or a mix of both... with the option of math incrementing by 1, starting with 1, in the counting channel!
+- `-CountingStatistics` - Show server stats for counting
+- `-CountingStatistics <user>` - Show user stats for counting
+- `-CountingStatistics Leaderboard` - Show server leaderboard for number of times counted correct by each user
+
+## Configuration
+
+- `$countTwice`<br />
+  Whether to allow users to count multiple times in a row.
+
+- `$correctRID`<br />
+  ID of role for most recent correct counting user.
+
+- `$incorrectRID`<br />
+  ID of role for incorrect counting users.
+
+- `$errorCID`<br />
+  ID of channel for any error output.
+
+- `$saves`<br />
+  Amount of saves from incorrect counts before the count resets.
+
+- `$reactions`<br />
+  Whether to enable or disable reaction confirmation.
+
+  - `$reactionDelete`<br />
+    Whether reactions from past messages should be removed.
+
+  - `$correctEmoji`<br />
+    Emoji to react with on correct messages.
+
+  - `$warningEmoji`<br />
+    Emoji to react with on incorrect messages that use a save.
+
+  - `$incorrectEmoji`<br />
+    Emoji to react with on incorrect messages.
+
+- `$leaderboardLength`<br />
+  Max amount of users that should be displayed on the leaderboard.
+
+## Code
+
+```gotmpl file=../../../src/fun/counting_v2.go.tmpl
+
+```
+
+## Author
+
+This custom command was written by [@H1nr1](https://github.com/H1nr1).

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -2,7 +2,7 @@
 title: Counting System
 ---
 
-This command controls the counting game and the statistics command.
+This command implements a counting game with detailed statistics and a leaderboard.
 
 This version of a counting command allows for the usage of base 10 and roman numerals, optionally joined by the usage of math functions and/or operators to count from 1, incrementing by 1, until failure.
 

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -10,9 +10,7 @@ This command controls the counting game and the statistics command.
 **Trigger:** `.+`
 
 :::note Restrictions
-
 Set this command to _only run_ in your counting channel in the channel restrictions.
-
 :::
 
 ## Usage
@@ -21,6 +19,10 @@ Set this command to _only run_ in your counting channel in the channel restricti
 - `-CountingStatistics` - Show server stats for counting
 - `-CountingStatistics <user>` - Show user stats for counting
 - `-CountingStatistics Leaderboard` - Show server leaderboard for number of times counted correct by each user
+
+:::tip Math Functionality
+To view all available math functions, see [Supported Functions, Operators, and Constants](https://github.com/ei14/calc#supported-functions-operators-and-constants)
+:::
 
 ## Configuration
 

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -10,7 +10,9 @@ This command controls the counting game and the statistics command.
 **Trigger:** `.+`
 
 :::note Restrictions
+
 Set this command to _only run_ in your counting channel in the channel restrictions.
+
 :::
 
 ## Usage
@@ -21,7 +23,9 @@ Set this command to _only run_ in your counting channel in the channel restricti
 - `-CountingStatistics Leaderboard` - Show server leaderboard for number of times counted correct by each user
 
 :::tip Math Functionality
+
 To view all available math functions, see [Supported Functions, Operators, and Constants](https://github.com/ei14/calc#supported-functions-operators-and-constants)
+
 :::
 
 ## Configuration

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -4,7 +4,7 @@ title: Counting System
 
 This command implements a counting game with detailed statistics and a leaderboard.
 
-This version of a counting command allows for the usage of base 10 and roman numerals, optionally joined by the usage of math functions and/or operators to count from 1, incrementing by 1, until failure.
+A unique feature of this command is that, besides decimal numbers, it also accepts roman numerals and mathematical expressions as valid inputs. So if the next number is 2, `II` and `2*sin(pi/2)` would be considered correct as well.
 
 Also included are statistics for the server and each user for how many times they have counted and how many times they've been correct.
 

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -4,6 +4,12 @@ title: Counting System
 
 This command controls the counting game and the statistics command.
 
+This version of a counting command allows for the usage of base 10 and roman numerals, optionally joined by the usage of math functions and/or operators to count from 1, incrementing by 1, until failure.
+
+Also included are statistics for the server and each user for how many times they have counted and how many times they've been correct.
+
+Messages without text are ignored by the system, effectively allowing unrelated content. However, messages including text which cannot be translated into a math expression will be quoted as invalid, but not deleted.
+
 ## Trigger
 
 **Type:** `Regex`<br />
@@ -43,7 +49,7 @@ To view all available math functions, see [Supported Functions, Operators, and C
   ID of channel for any error output.
 
 - `$saves`<br />
-  Amount of saves from incorrect counts before the count resets.
+  Amount of incorrect expressions which can be sent before the count resets.
 
 - `$reactions`<br />
   Whether to enable or disable reaction confirmation.

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -8,9 +8,11 @@ A unique feature of this command is that, besides decimal numbers, it also accep
 
 :::note
 
-Unlike some other counting systems, this command does not delete invalid numbers to allow counting and other conversation to take place concurrently. Messages that include text which do not correspond to valid numbers will, however, trigger a warning message.
+Unlike some other counting systems, this command does not delete invalid expressions to allow counting and other conversation to take place concurrently. Expressions which include unaccepted terms or are invalid will, however, trigger a warning message.
 
 :::
+
+The expression must appear on the first line entirely on its own for the count to increase.
 
 ## Trigger
 

--- a/website/docs/fun/counting_v2.md
+++ b/website/docs/fun/counting_v2.md
@@ -6,9 +6,11 @@ This command implements a counting game with detailed statistics and a leaderboa
 
 A unique feature of this command is that, besides decimal numbers, it also accepts roman numerals and mathematical expressions as valid inputs. So if the next number is 2, `II` and `2*sin(pi/2)` would be considered correct as well.
 
-Also included are statistics for the server and each user for how many times they have counted and how many times they've been correct.
+:::note
 
 Unlike some other counting systems, this command does not delete invalid numbers to allow counting and other conversation to take place concurrently. Messages that include text which do not correspond to valid numbers will, however, trigger a warning message.
+
+:::
 
 ## Trigger
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This version of a counting command allows for the usage of base 10 and roman numerals, optionally joined by the usage of math functions and/or operators to count from 1, incrementing by 1, until failure.

With a range of configurable variables, the user can chose to have the ability to count twice, or more, in a row, roles for correct counting users and incorrect counting users, effectively allowing a blacklist; saves, reactions, and more!

Also bundled in this command is a statistics command, with optional arguments to view server or user stats individually or a leaderboard for users which have counted correctly the most times.

Possible changes/request for help deciding
- As the character count is nearly 10k, even the configuring of variables may push it over. Where would be best to slim down without losing readability? I include quite a bit of space around and within comments which could be removed. The comments to help the user configure the variables could possibly be removed, or at least shortened, given they are described in the command docs. I would rather not ask the user to remove anything themselves; for example, the header comment, as I've seen elsewhere. Splitting the counting and stats command as I originally had it is an option; I wanted it to be easier to "install" and therefore combined them not thinking it'd be this close.

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
