### PR TITLE
fun/coinflip: rewrite

### DIFF
--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -92,8 +92,8 @@
 	{{ end }}
 
 	{{ $balance := dbIncr .User.ID $DB_KEY $bet | toInt }}
-	{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou %s **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $result.side $result.WL $result.diff $balance) }}
-	{{ dbSetExpire .User.ID "cd_coinflip" true $COOLDOWN }}
-	{{ dbDel .User.ID "isrolling_cf" }}
+	{{ $embed.Set "description" (printf "**----------**\nYou chose **%s** | The coin landed on **%s**.\nYou %s **%d** %s.\nNow you have **%d** %s.\n**----------**" $choice $result.side $result.WL $result.diff (lower $DB_KEY) $balance (lower $DB_KEY)) }}
+	{{ dbSetExpire .User.ID "CF_cooldown" true $COOLDOWN }}
+	{{ dbDel .User.ID "CF_isFlipping" }}
 	{{ editMessage $channel $m (cembed $embed) }}
 {{ end }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -43,12 +43,14 @@
 		{{ $err = printf "Maximum bet can only be **%d**!" $MAX_BET }}
 	{{ end }}
 
-	{{ if dbGet .User.ID "cd_coinflip" }}
-		{{ $err = print "You need to wait **" (humanizeDurationSeconds ((dbGet .User.ID "cd_coinflip").ExpiresAt.Sub currentTime)) "** to use this command again." }}
+	{{ $cd := dbGet .User.ID "cd_coinflip" }}
+	{{ if $cd }}
+		{{ $err = print "You need to wait **" ($cd.ExpiresAt.Sub currentTime | humanizeDurationSeconds) "** to use this command again." }}
 	{{ end }}
 
-	{{ if lt (toInt (dbGet .User.ID $DB_KEY).Value) $bet }}
-		{{ $err = printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet .User.ID $DB_KEY).Value) }}
+	{{ $userBalance := (dbGet .User.ID $DB_KEY).Value | toInt }}
+	{{ if lt $userBalance $bet }}
+		{{ $err = printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet $userBalance }}
 	{{ end }}
 
 	{{ if dbGet .User.ID "isrolling_cf" }}
@@ -64,7 +66,7 @@
 		{{ return }}
 	{{ end }}
 
-	{{/* roll may proceed */}}
+	{{/* flip may proceed */}}
 	{{ dbSet .User.ID "isrolling_cf" true }}
 	{{ $embed.Set "image" (sdict "url" $img) }}
 	{{ $embed.Set "color" 16765696 }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -3,118 +3,117 @@
 	See <https://yagpdb-cc.github.io/fun/coinflip> for more information.
 
 	Author: DaviiD1337 <https://github.com/DaviiD1337>
+	Co-Author: H1nr1 <https://github.com/H1nr1>
 */}}
 
 {{/* Configuration variables start */}}
 {{ $channel := .Channel.ID }}
-{{ $minbet := 100 }}
-{{ $maxbet := 500 }}
+{{ $minBet := 100 }}
+{{ $maxBet := 500 }}
 {{ $db := "CREDITS" }}
-{{ $cooldown := 5 }} {{/* cannot be 0 */}}
-{{ $channels := cslice
-  752497563298562118
-  722554898612355093
-  744670631601111222
-  782711001333235734
-  783021217279246356
- }}
+{{ $cooldown := 5 }}
 {{/* Configuration variables end */}}
 
-{{ range $channels }}
-	{{ if not (getChannel .) }}
-		{{ print "Error: Configuration is not set correct. Channel with ID  `" . "` not found. (`$channels`)" }}
-		{{ deleteTrigger 5 }}
-		{{ deleteResponse 5 }}
-		{{ return }}
-	{{ end }}
-{{ end }}
+{{ $err := false }}
+{{ $img := "https://cdn.discordapp.com/attachments/707661790443733022/782710794634264616/d74906d39a1964e7d07555e7601b06ad.gif" }}
+{{ $heads := "https://cdn.discordapp.com/attachments/707661790443733022/782713935341027358/cap.png" }}
+{{ $tails := "https://cdn.discordapp.com/attachments/707661790443733022/782713937979637760/pajura.png" }}
+{{ $embed := sdict "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256")) }}
 
-{{ $cp := "" }}{{ $m := 0 }}{{ $bet := "" }}{{ $err := false }}{{ $img := "https://cdn.discordapp.com/attachments/707661790443733022/782710794634264616/d74906d39a1964e7d07555e7601b06ad.gif" }}{{ $cap := "https://cdn.discordapp.com/attachments/707661790443733022/782713935341027358/cap.png" }}{{ $pajura := "https://cdn.discordapp.com/attachments/707661790443733022/782713937979637760/pajura.png" }}{{ $embed:= sdict }}{{ $fields := cslice }}{{ $embed.Set "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256"))}}
 {{ if not .ExecData }}
-	{{ if eq (len .CmdArgs) 2 }}
-		{{ with reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}
-			{{ $cp = . | lower }}
-			{{ with reFindAll `\d+` (index $.CmdArgs 1) }}
-				{{ $bet = index . 0 | toInt }}
-				{{ if ge $bet $minbet }}
-					{{ if le $bet $maxbet }}
-						{{ if not (dbGet $.User.ID "cd_coinflip") }}
-							{{ if ge (toInt (dbGet $.User.ID $db).Value) $bet }}
-								{{ if not (dbGet $.User.ID "isrolling_cf") }}
-									{{ dbSet $.User.ID "isrolling_cf" true }}
-									{{ $embed.Set "image" (sdict "url" $img) }}
-									{{ $embed.Set "color" 16765696 }}
-									{{ $embed.Set "description" "**The coin is rolling... Wait...**" }}
-									{{ $m = sendMessageRetID $channel (cembed $embed) }}
-									{{ scheduleUniqueCC $.CCID (index (shuffle $channels) 0) 3 $.User.ID (sdict "m" $m "b" $bet "c" $cp )}}
-								{{ else }}
-									{{ $embed.Set "description" "You can use this command when the last coin stopped rolling!" }}
-									{{ $embed.Set "color" 16488706 }}
-									{{ $err = true }}
-								{{ end }}
-							{{ else }}
-								{{ $embed.Set "description" (printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet $.User.ID $db).Value)) }}
-								{{ $embed.Set "color" 16488706 }}
-								{{ $err = true }}
-							{{ end }}
-						{{ else }}
-							{{ $embed.Set "description" (print "You need to wait **" (humanizeDurationSeconds ((dbGet $.User.ID "cd_coinflip").ExpiresAt.Sub currentTime)) "** to use this command again.") }}
-							{{ $embed.Set "color" 16488706 }}
-							{{ $err = true }}
-						{{ end }}
-					{{ else }}
-						{{ $embed.Set "description" (printf "Maximum bet can only be **%d**!" $maxbet) }}
-						{{ $embed.Set "color" 16488706 }}
-						{{ $err = true }}
-					{{ end }}
-				{{ else }}
-					{{ $embed.Set "description" (printf "Minimum bet can only be **%d**!" $minbet) }}
-					{{ $embed.Set "color" 16488706 }}
-					{{ $err = true }}
-				{{ end }}
-			{{ else }}
-				{{ $embed.Set "description" (printf "`%s` is not a valid number." (index $.CmdArgs 1)) }}
-				{{ $embed.Set "color" 16488706 }}
-				{{ $err = true }}
-			{{ end }}
-		{{ else }}
-			{{ $embed.Set "description" "You can only choose from **heads** or **tails**." }}
-			{{ $embed.Set "color" 16488706 }}
-			{{ $err = true }}
-		{{ end }}
-	{{ else }}
+	{{ if not (eq (len .CmdArgs) 2) }}
 		{{ $embed.Set "description" (printf "Syntax: **%scoinflip <heads/tails> <money>**" .ServerPrefix) }}
 		{{ $embed.Set "color" 16488706 }}
 		{{ $err = true }}
 	{{ end }}
+
+	{{ $choice := reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}
+	{{ if not $choice }}
+		{{ $embed.Set "description" "You can only choose from **heads** or **tails**." }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
+	{{ $bet := reFind `\d+` (index .CmdArgs 1) | toInt }}
+	{{ if not $bet }}
+		{{ $embed.Set "description" (printf "`%s` is not a valid number." (index .CmdArgs 1)) }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
+	{{ if lt $bet $minBet }}
+		{{ $embed.Set "description" (printf "Minimum bet can only be **%d**!" $minBet) }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
+	{{ if gt $bet $maxBet }}
+		{{ $embed.Set "description" (printf "Maximum bet can only be **%d**!" $maxBet) }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
+	{{ if dbGet .User.ID "cd_coinflip" }}
+		{{ $embed.Set "description" (print "You need to wait **" (humanizeDurationSeconds ((dbGet .User.ID "cd_coinflip").ExpiresAt.Sub currentTime)) "** to use this command again.") }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
+	{{ if lt (toInt (dbGet .User.ID $db).Value) $bet }}
+		{{ $embed.Set "description" (printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet .User.ID $db).Value)) }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
+	{{ if dbGet .User.ID "isrolling_cf" }}
+		{{ $embed.Set "description" "You can use this command when the last coin stopped rolling!" }}
+		{{ $embed.Set "color" 16488706 }}
+		{{ $err = true }}
+	{{ end }}
+
 	{{ if $err }}
 		{{ $message := sendMessageRetID nil (cembed $embed) }}
 		{{ deleteMessage .Channel.ID $message 5 }}
 		{{ deleteTrigger }}
+		{{ return }}
 	{{ end }}
+
+	{{/* roll may proceed */}}
+	{{ dbSet .User.ID "isrolling_cf" true }}
+	{{ $embed.Set "image" (sdict "url" $img) }}
+	{{ $embed.Set "color" 16765696 }}
+	{{ $embed.Set "description" "**The coin is rolling... Wait...**" }}
+	{{ $m := sendMessageRetID $channel (cembed $embed) }}
+	{{ $randChannel := (index .Guild.Channels (randInt (len .Guild.Channels))).ID }}
+	{{ scheduleUniqueCC .CCID $randChannel 3 .User.ID (sdict "channel" $channel "m" $m "b" $bet "c" $choice )}}
+
 {{ else }}
-	{{ $m = .ExecData.m }}
-	{{ $bet = .ExecData.b }}
-	{{ $cp = .ExecData.c }}
+	{{ $channel = .ExecData.channel }}
+	{{ $m := .ExecData.m }}
+	{{ $bet := .ExecData.b }}
+	{{ $choice := .ExecData.c }}
 	{{ $chance := randInt 1 3 }}
 	{{ $choosen := "" }}
+
 	{{ if eq $chance 1 }}
 		{{ $choosen = "heads" }}
-		{{ $embed.Set "image" (sdict "url" $cap) }}
+		{{ $embed.Set "image" (sdict "url" $heads) }}
 	{{ else }}
 		{{ $choosen = "tails" }}
-		{{ $embed.Set "image" (sdict "url" $pajura)}}
+		{{ $embed.Set "image" (sdict "url" $tails)}}
 	{{ end }}
-	{{ if eq $cp $choosen }}
-		{{ $k := dbIncr $.User.ID $db $bet }}
-		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou won **%d** credits.\nNow you have **%d** credits.\n**----------**" $cp $choosen (mult $bet 2) (toInt $k)) }}
+
+	{{ if eq $choice $choosen }}
+		{{ $k := dbIncr .User.ID $db $bet }}
+		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou won **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $choosen (mult $bet 2) (toInt $k)) }}
 		{{ $embed.Set "color" 40811 }}
 	{{ else }}
-		{{ $k := dbIncr $.User.ID $db (mult $bet -1) }}
-		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou lost **%d** credits.\nNow you have **%d** credits.\n**----------**" $cp $choosen $bet (toInt $k)) }}
+		{{ $k := dbIncr .User.ID $db (mult $bet -1) }}
+		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou lost **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $choosen $bet (toInt $k)) }}
 		{{ $embed.Set "color" 16488706 }}
 	{{ end }}
-	{{ dbSetExpire $.User.ID "cd_coinflip" true $cooldown }}
-	{{ dbDel $.User.ID "isrolling_cf" }}
+
+	{{ dbSetExpire .User.ID "cd_coinflip" true $cooldown }}
+	{{ dbDel .User.ID "isrolling_cf" }}
 	{{ editMessage $channel $m (cembed $embed) }}
 {{ end }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -45,8 +45,8 @@
 	{{ else if lt ($userBalance := (dbGet .User.ID $DB_KEY).Value | toInt) $bet }}
 		{{ $err = printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet $userBalance }}
 
-	{{ else if dbGet .User.ID "isrolling_cf" }}
-		{{ $err = "You can use this command when the last coin stopped rolling!" }}
+	{{ else if dbGet .User.ID "CF_isFlipping" }}
+		{{ $err = "You can use this command once your last coin has landed!" }}
 	{{ end }}
 
 	{{ if $err }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -22,7 +22,7 @@
 
 {{ if not .ExecData }}
 	{{ if not (eq (len .CmdArgs) 2) }}
-		{{ $err = printf "Syntax: **%scoinflip <heads/tails> <money>**" .ServerPrefix }}
+		{{ $err = printf "Syntax: **%scoinflip <heads/tails> <bet>**" .ServerPrefix }}
 	{{ end }}
 
 	{{ $choice := reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -6,7 +6,7 @@
 */}}
 
 {{/* Configuration variables start */}}
-{{ $c := 815223392114180096 }}
+{{ $channel := .Channel.ID }}
 {{ $minbet := 100 }}
 {{ $maxbet := 500 }}
 {{ $db := "CREDITS" }}
@@ -45,7 +45,7 @@
 									{{ $embed.Set "image" (sdict "url" $img) }}
 									{{ $embed.Set "color" 16765696 }}
 									{{ $embed.Set "description" "**The coin is rolling... Wait...**" }}
-									{{ $m = sendMessageRetID $c (cembed $embed) }}
+									{{ $m = sendMessageRetID $channel (cembed $embed) }}
 									{{ scheduleUniqueCC $.CCID (index (shuffle $channels) 0) 3 $.User.ID (sdict "m" $m "b" $bet "c" $cp )}}
 								{{ else }}
 									{{ $embed.Set "description" "You can use this command when the last coin stopped rolling!" }}
@@ -116,5 +116,5 @@
 	{{ end }}
 	{{ dbSetExpire $.User.ID "cd_coinflip" true $cooldown }}
 	{{ dbDel $.User.ID "isrolling_cf" }}
-	{{ editMessage $c $m (cembed $embed) }}
+	{{ editMessage $channel $m (cembed $embed) }}
 {{ end }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -7,11 +7,11 @@
 */}}
 
 {{/* Configuration variables start */}}
-{{ $channel := .Channel.ID }}
-{{ $minBet := 100 }}
-{{ $maxBet := 500 }}
-{{ $db := "CREDITS" }}
-{{ $cooldown := 5 }}
+{{ $CHANNEL := .Channel.ID }}
+{{ $MIN_BET := 100 }}
+{{ $MAX_BET := 500 }}
+{{ $DB_KEY := "CREDITS" }}
+{{ $COOLDOWN := 5 }}
 {{/* Configuration variables end */}}
 
 {{ $err := false }}
@@ -41,14 +41,14 @@
 		{{ $err = true }}
 	{{ end }}
 
-	{{ if lt $bet $minBet }}
-		{{ $embed.Set "description" (printf "Minimum bet can only be **%d**!" $minBet) }}
+	{{ if lt $bet $MIN_BET }}
+		{{ $embed.Set "description" (printf "Minimum bet can only be **%d**!" $MIN_BET) }}
 		{{ $embed.Set "color" 16488706 }}
 		{{ $err = true }}
 	{{ end }}
 
-	{{ if gt $bet $maxBet }}
-		{{ $embed.Set "description" (printf "Maximum bet can only be **%d**!" $maxBet) }}
+	{{ if gt $bet $MAX_BET }}
+		{{ $embed.Set "description" (printf "Maximum bet can only be **%d**!" $MAX_BET) }}
 		{{ $embed.Set "color" 16488706 }}
 		{{ $err = true }}
 	{{ end }}
@@ -59,8 +59,8 @@
 		{{ $err = true }}
 	{{ end }}
 
-	{{ if lt (toInt (dbGet .User.ID $db).Value) $bet }}
-		{{ $embed.Set "description" (printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet .User.ID $db).Value)) }}
+	{{ if lt (toInt (dbGet .User.ID $DB_KEY).Value) $bet }}
+		{{ $embed.Set "description" (printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet .User.ID $DB_KEY).Value)) }}
 		{{ $embed.Set "color" 16488706 }}
 		{{ $err = true }}
 	{{ end }}
@@ -83,12 +83,12 @@
 	{{ $embed.Set "image" (sdict "url" $img) }}
 	{{ $embed.Set "color" 16765696 }}
 	{{ $embed.Set "description" "**The coin is rolling... Wait...**" }}
-	{{ $m := sendMessageRetID $channel (cembed $embed) }}
+	{{ $m := sendMessageRetID $CHANNEL (cembed $embed) }}
 	{{ $randChannel := (index .Guild.Channels (randInt (len .Guild.Channels))).ID }}
-	{{ scheduleUniqueCC .CCID $randChannel 3 .User.ID (sdict "channel" $channel "m" $m "b" $bet "c" $choice )}}
+	{{ scheduleUniqueCC .CCID $randChannel 3 .User.ID (sdict "channel" $CHANNEL "m" $m "b" $bet "c" $choice )}}
 
 {{ else }}
-	{{ $channel = .ExecData.channel }}
+	{{ $channel := .ExecData.channel }}
 	{{ $m := .ExecData.m }}
 	{{ $bet := .ExecData.b }}
 	{{ $choice := .ExecData.c }}
@@ -104,16 +104,16 @@
 	{{ end }}
 
 	{{ if eq $choice $choosen }}
-		{{ $k := dbIncr .User.ID $db $bet }}
+		{{ $k := dbIncr .User.ID $DB_KEY $bet }}
 		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou won **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $choosen (mult $bet 2) (toInt $k)) }}
 		{{ $embed.Set "color" 40811 }}
 	{{ else }}
-		{{ $k := dbIncr .User.ID $db (mult $bet -1) }}
+		{{ $k := dbIncr .User.ID $DB_KEY (mult $bet -1) }}
 		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou lost **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $choosen $bet (toInt $k)) }}
 		{{ $embed.Set "color" 16488706 }}
 	{{ end }}
 
-	{{ dbSetExpire .User.ID "cd_coinflip" true $cooldown }}
+	{{ dbSetExpire .User.ID "cd_coinflip" true $COOLDOWN }}
 	{{ dbDel .User.ID "isrolling_cf" }}
 	{{ editMessage $channel $m (cembed $embed) }}
 {{ end }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -62,7 +62,7 @@
 	{{ dbSet .User.ID "CF_isFlipping" true }}
 	{{ $embed.Set "image" (sdict "url" $img) }}
 	{{ $embed.Set "color" 16765696 }}
-	{{ $embed.Set "description" "**The coin is rolling... Please wait...**" }}
+	{{ $embed.Set "description" "**The coin is in the air... Please wait for it to land...**" }}
 	{{ $m := sendMessageRetID $CHANNEL (cembed $embed) }}
 	{{ $randChannel := (index .Guild.Channels (randInt (len .Guild.Channels))).ID }}
 	{{ scheduleUniqueCC .CCID $randChannel 3 .User.ID (sdict "channel" $CHANNEL "m" $m "b" $bet "c" $choice )}}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -70,7 +70,7 @@
 	{{ dbSet .User.ID "isrolling_cf" true }}
 	{{ $embed.Set "image" (sdict "url" $img) }}
 	{{ $embed.Set "color" 16765696 }}
-	{{ $embed.Set "description" "**The coin is rolling... Wait...**" }}
+	{{ $embed.Set "description" "**The coin is rolling... Please wait...**" }}
 	{{ $m := sendMessageRetID $CHANNEL (cembed $embed) }}
 	{{ $randChannel := (index .Guild.Channels (randInt (len .Guild.Channels))).ID }}
 	{{ scheduleUniqueCC .CCID $randChannel 3 .User.ID (sdict "channel" $CHANNEL "m" $m "b" $bet "c" $choice )}}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -71,7 +71,7 @@
 	{{ $channel := .ExecData.channel }}
 	{{ $m := .ExecData.m }}
 	{{ $bet := .ExecData.b }}
-	{{ $choice := .ExecData.c }}
+	{{ $choice := print .ExecData.c "s" }}
 
 	{{ $result := (dict 
 		0 (sdict "side" "heads" "img" $heads)
@@ -92,7 +92,7 @@
 	{{ end }}
 
 	{{ $balance := dbIncr .User.ID $DB_KEY $bet | toInt }}
-	{{ $embed.Set "description" (printf "**----------**\nYou chose **%ss** | The coin landed on **%s**.\nYou %s **%d** %s.\nNow you have **%d** %s.\n**----------**" $choice $result.side $result.WL $result.diff (lower $DB_KEY) $balance (lower $DB_KEY)) }}
+	{{ $embed.Set "description" (printf "**----------**\nYou chose **%s** | The coin landed on **%s**.\nYou %s **%d** %s.\nNow you have **%d** %s.\n**----------**" $choice $result.side $result.WL $result.diff (lower $DB_KEY) $balance (lower $DB_KEY)) }}
 	{{ dbSetExpire .User.ID "CF_cooldown" true $COOLDOWN }}
 	{{ dbDel .User.ID "CF_isFlipping" }}
 	{{ editMessage $channel $m (cembed $embed) }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -80,27 +80,27 @@
 	{{ $m := .ExecData.m }}
 	{{ $bet := .ExecData.b }}
 	{{ $choice := .ExecData.c }}
-	{{ $chance := randInt 1 3 }}
-	{{ $choosen := "" }}
 
-	{{ if eq $chance 1 }}
-		{{ $choosen = "heads" }}
-		{{ $embed.Set "image" (sdict "url" $heads) }}
-	{{ else }}
-		{{ $choosen = "tails" }}
-		{{ $embed.Set "image" (sdict "url" $tails)}}
-	{{ end }}
+	{{ $result := (dict 
+		0 (sdict "side" "heads" "img" $heads)
+		1 (sdict "side" "tails" "img" $tails)
+	).Get (randInt 2) }}
 
-	{{ if eq $choice $choosen }}
-		{{ $k := dbIncr .User.ID $DB_KEY $bet }}
-		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou won **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $choosen (mult $bet 2) (toInt $k)) }}
+	{{ $embed.Set "image" (sdict "url" $result.img) }}
+
+	{{ if eq $choice $result.side }}
+		{{ $result.Set "WL" "won" }}
+		{{ $result.Set "diff" (mult $bet 2) }}
 		{{ $embed.Set "color" 40811 }}
 	{{ else }}
-		{{ $k := dbIncr .User.ID $DB_KEY (mult $bet -1) }}
-		{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou lost **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $choosen $bet (toInt $k)) }}
+		{{ $result.Set "WL" "lost" }}
+		{{ $result.Set "diff" $bet }}
+		{{ $bet = mult $bet -1 }}
 		{{ $embed.Set "color" 16488706 }}
 	{{ end }}
 
+	{{ $balance := dbIncr .User.ID $DB_KEY $bet | toInt }}
+	{{ $embed.Set "description" (printf "**----------**\nYou chose: **%s** | The coin rolled: **%s**.\nYou %s **%d** credits.\nNow you have **%d** credits.\n**----------**" $choice $result.side $result.WL $result.diff $balance) }}
 	{{ dbSetExpire .User.ID "cd_coinflip" true $COOLDOWN }}
 	{{ dbDel .User.ID "isrolling_cf" }}
 	{{ editMessage $channel $m (cembed $embed) }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -28,10 +28,10 @@
 		{{ $err = printf "Syntax: **%scoinflip <heads/tails> <bet>**" .ServerPrefix }}
 
 	{{ else if not $choice }}
-		{{ $err = "You can only choose from **heads** or **tails**." }}
+		{{ $err = "You can only choose from **heads** or **tails**" }}
 
 	{{ else if not $bet }}
-		{{ $err = printf "`%s` is not a valid number." (index .CmdArgs 1) }}
+		{{ $err = printf "Please provide a bet between **%d** and **%d**" $MIN_BET $MAX_BET }}
 
 	{{ else if lt $bet $MIN_BET }}
 		{{ $err = printf "Minimum bet can only be **%d**!" $MIN_BET }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -22,56 +22,42 @@
 
 {{ if not .ExecData }}
 	{{ if not (eq (len .CmdArgs) 2) }}
-		{{ $embed.Set "description" (printf "Syntax: **%scoinflip <heads/tails> <money>**" .ServerPrefix) }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = printf "Syntax: **%scoinflip <heads/tails> <money>**" .ServerPrefix }}
 	{{ end }}
 
 	{{ $choice := reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}
 	{{ if not $choice }}
-		{{ $embed.Set "description" "You can only choose from **heads** or **tails**." }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = "You can only choose from **heads** or **tails**." }}
 	{{ end }}
 
 	{{ $bet := reFind `\d+` (index .CmdArgs 1) | toInt }}
 	{{ if not $bet }}
-		{{ $embed.Set "description" (printf "`%s` is not a valid number." (index .CmdArgs 1)) }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = printf "`%s` is not a valid number." (index .CmdArgs 1) }}
 	{{ end }}
 
 	{{ if lt $bet $MIN_BET }}
-		{{ $embed.Set "description" (printf "Minimum bet can only be **%d**!" $MIN_BET) }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = printf "Minimum bet can only be **%d**!" $MIN_BET }}
 	{{ end }}
 
 	{{ if gt $bet $MAX_BET }}
-		{{ $embed.Set "description" (printf "Maximum bet can only be **%d**!" $MAX_BET) }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = printf "Maximum bet can only be **%d**!" $MAX_BET }}
 	{{ end }}
 
 	{{ if dbGet .User.ID "cd_coinflip" }}
-		{{ $embed.Set "description" (print "You need to wait **" (humanizeDurationSeconds ((dbGet .User.ID "cd_coinflip").ExpiresAt.Sub currentTime)) "** to use this command again.") }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = print "You need to wait **" (humanizeDurationSeconds ((dbGet .User.ID "cd_coinflip").ExpiresAt.Sub currentTime)) "** to use this command again." }}
 	{{ end }}
 
 	{{ if lt (toInt (dbGet .User.ID $DB_KEY).Value) $bet }}
-		{{ $embed.Set "description" (printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet .User.ID $DB_KEY).Value)) }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet (toInt (dbGet .User.ID $DB_KEY).Value) }}
 	{{ end }}
 
 	{{ if dbGet .User.ID "isrolling_cf" }}
-		{{ $embed.Set "description" "You can use this command when the last coin stopped rolling!" }}
-		{{ $embed.Set "color" 16488706 }}
-		{{ $err = true }}
+		{{ $err = "You can use this command when the last coin stopped rolling!" }}
 	{{ end }}
 
 	{{ if $err }}
+		{{ $embed.Set "description" $err }}
+		{{ $embed.Set "color" 16488706 }}
 		{{ $message := sendMessageRetID nil (cembed $embed) }}
 		{{ deleteMessage .Channel.ID $message 5 }}
 		{{ deleteTrigger }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -21,39 +21,31 @@
 {{ $embed := sdict "author" (sdict "name" .User.Username "icon_url" (.User.AvatarURL "256")) }}
 
 {{ if not .ExecData }}
+	{{ $choice := reFind `(?i)head|tail` .StrippedMsg | lower }}
+	{{ $bet := reFind `\d+` .StrippedMsg | toInt }}
+
 	{{ if not (eq (len .CmdArgs) 2) }}
 		{{ $err = printf "Syntax: **%scoinflip <heads/tails> <bet>**" .ServerPrefix }}
-	{{ end }}
 
-	{{ $choice := reFind `\A(?i)(heads|tails)\z` (index .CmdArgs 0) }}
-	{{ if not $choice }}
+	{{ else if not $choice }}
 		{{ $err = "You can only choose from **heads** or **tails**." }}
-	{{ end }}
 
-	{{ $bet := reFind `\d+` (index .CmdArgs 1) | toInt }}
-	{{ if not $bet }}
+	{{ else if not $bet }}
 		{{ $err = printf "`%s` is not a valid number." (index .CmdArgs 1) }}
-	{{ end }}
 
-	{{ if lt $bet $MIN_BET }}
+	{{ else if lt $bet $MIN_BET }}
 		{{ $err = printf "Minimum bet can only be **%d**!" $MIN_BET }}
-	{{ end }}
 
-	{{ if gt $bet $MAX_BET }}
+	{{ else if gt $bet $MAX_BET }}
 		{{ $err = printf "Maximum bet can only be **%d**!" $MAX_BET }}
-	{{ end }}
 
-	{{ $cd := dbGet .User.ID "cd_coinflip" }}
-	{{ if $cd }}
+	{{ else if $cd := dbGet .User.ID "cd_coinflip" }}
 		{{ $err = print "You need to wait **" ($cd.ExpiresAt.Sub currentTime | humanizeDurationSeconds) "** to use this command again." }}
-	{{ end }}
 
-	{{ $userBalance := (dbGet .User.ID $DB_KEY).Value | toInt }}
-	{{ if lt $userBalance $bet }}
+	{{ else if lt ($userBalance := (dbGet .User.ID $DB_KEY).Value | toInt) $bet }}
 		{{ $err = printf "You dont have **%d** credits.\nYou only have **%d** credits." $bet $userBalance }}
-	{{ end }}
 
-	{{ if dbGet .User.ID "isrolling_cf" }}
+	{{ else if dbGet .User.ID "isrolling_cf" }}
 		{{ $err = "You can use this command when the last coin stopped rolling!" }}
 	{{ end }}
 

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -92,7 +92,7 @@
 	{{ end }}
 
 	{{ $balance := dbIncr .User.ID $DB_KEY $bet | toInt }}
-	{{ $embed.Set "description" (printf "**----------**\nYou chose **%s** | The coin landed on **%s**.\nYou %s **%d** %s.\nNow you have **%d** %s.\n**----------**" $choice $result.side $result.WL $result.diff (lower $DB_KEY) $balance (lower $DB_KEY)) }}
+	{{ $embed.Set "description" (printf "**----------**\nYou chose **%ss** | The coin landed on **%s**.\nYou %s **%d** %s.\nNow you have **%d** %s.\n**----------**" $choice $result.side $result.WL $result.diff (lower $DB_KEY) $balance (lower $DB_KEY)) }}
 	{{ dbSetExpire .User.ID "CF_cooldown" true $COOLDOWN }}
 	{{ dbDel .User.ID "CF_isFlipping" }}
 	{{ editMessage $channel $m (cembed $embed) }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -39,7 +39,7 @@
 	{{ else if gt $bet $MAX_BET }}
 		{{ $err = printf "Maximum bet can only be **%d**!" $MAX_BET }}
 
-	{{ else if $cd := dbGet .User.ID "cd_coinflip" }}
+	{{ else if $cd := dbGet .User.ID "CF_cooldown" }}
 		{{ $err = print "You need to wait **" ($cd.ExpiresAt.Sub currentTime | humanizeDurationSeconds) "** to use this command again." }}
 
 	{{ else if lt ($userBalance := (dbGet .User.ID $DB_KEY).Value | toInt) $bet }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -33,11 +33,8 @@
 	{{ else if not $bet }}
 		{{ $err = printf "Please provide a bet between **%d** and **%d**" $MIN_BET $MAX_BET }}
 
-	{{ else if lt $bet $MIN_BET }}
-		{{ $err = printf "Minimum bet can only be **%d**!" $MIN_BET }}
-
-	{{ else if gt $bet $MAX_BET }}
-		{{ $err = printf "Maximum bet can only be **%d**!" $MAX_BET }}
+	{{ else if or (lt $bet $MIN_BET) (gt $bet $MAX_BET) }}
+		{{ $err = printf "Bet must be minimum **%d** and maximum **%d**!" $MIN_BET $MAX_BET }}
 
 	{{ else if $cd := dbGet .User.ID "CF_cooldown" }}
 		{{ $err = print "You need to wait **" ($cd.ExpiresAt.Sub currentTime | humanizeDurationSeconds) "** to use this command again." }}

--- a/src/fun/coinflip.go.tmpl
+++ b/src/fun/coinflip.go.tmpl
@@ -59,7 +59,7 @@
 	{{ end }}
 
 	{{/* flip may proceed */}}
-	{{ dbSet .User.ID "isrolling_cf" true }}
+	{{ dbSet .User.ID "CF_isFlipping" true }}
 	{{ $embed.Set "image" (sdict "url" $img) }}
 	{{ $embed.Set "color" 16765696 }}
 	{{ $embed.Set "description" "**The coin is rolling... Please wait...**" }}

--- a/website/docs/fun/coinflip.md
+++ b/website/docs/fun/coinflip.md
@@ -2,7 +2,7 @@
 title: Coin Flip
 ---
 
-This command is a game of heads or tails which users can play.
+This command flips a coin landing on heads or tails to lose or double the bet.
 
 ## Trigger
 
@@ -15,19 +15,19 @@ This command is a game of heads or tails which users can play.
 
 ## Configuration
 
-- 📌 `$c`<br />
-  Channel ID where the game is played.
+- 📌 `$CHANNEL`<br />
+  Channel ID where the game is played. Set to `.Channel.ID` to allow play in any channel.
 
-- `$minbet`<br />
-  Minimum amount people can bet.
+- `$MIN_BET`<br />
+  Minimum amount users can bet.
 
-- `$maxbet`<br />
-  Maximum amount people can bet.
+- `$MAX_BET`<br />
+  Maximum amount users can bet.
 
-- 📌 `$db`<br />
-  Database entry name where the credits are stored.
+- 📌 `$DB_KEY`<br />
+  Database entry name where the currency is stored.
 
-- `$cooldown`<br />
+- `$COOLDOWN`<br />
   Cooldown for the command in seconds.
 
 ## Code
@@ -38,4 +38,4 @@ This command is a game of heads or tails which users can play.
 
 ## Author
 
-This custom command was written by [@DaviiD1337](https://github.com/DaviiD1337).
+This custom command was written by [@DaviiD1337](https://github.com/DaviiD1337) with contributions from [@H1nr1](https://github.com/H1nr1).

--- a/website/docs/fun/coinflip.md
+++ b/website/docs/fun/coinflip.md
@@ -4,6 +4,12 @@ title: Coin Flip
 
 This command flips a coin landing on heads or tails to lose or double the bet.
 
+:::caution
+
+This command assumes that you have an existing currency system set up.
+
+:::
+
 ## Trigger
 
 **Type:** `Command`<br />


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Initiate a draft PR for coinflip.

I intended to remove the nesting of if statements. I have realized after a deeper review, that many things can and should be updated, so much so that I would rather rewrite the command in my own fashion. I believe coinflip is a simple command and does not necessarily need a second version; but how could we preserve David's involvement if I were to rewrite it? I will include most features in my rewrite, but notably removing the need for a channel list and `scheduleUniqueCC`.

**Status**

- [X] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [X] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [X] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
