### PR TITLE
bug: race condition

### DIFF
--- a/src/fun/qotd/advanced/component_handler.go.tmpl
+++ b/src/fun/qotd/advanced/component_handler.go.tmpl
@@ -214,4 +214,12 @@
 {{ end }}
 {{ $m := sdict "embed" $embed "components" $comps }}
 {{ updateMessage (complexMessageEdit $m) }}
+{{ if in $id "queue_channel" }}
+  {{/* Prevent an execCC race condition when configuring queue channel message */}}
+  {{ sleep 3 }}
+  {{ $maybeNewCfg := dbGet 0 "qotd-config" }}
+  {{ if ne ( $n := $maybeNewCfg.Value.QueueMessage | toInt64 ) ( $o := $cfg.QueueMessage | toInt64 ) }}
+    {{ $cfg.Set "QueueMessage" ( or $n $o ) }}
+  {{ end }}
+{{ end }}
 {{ dbSet 0 "qotd-config" $cfg }}


### PR DESCRIPTION
Addresses a race condition where the component handler and a CC it executes would fight for the last DB assignment for config. Now the component handler is a nice guy, and additionally it  merges the config from both CCs before saving.

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
